### PR TITLE
bug: The plugin cannot lazy load

### DIFF
--- a/plugin/chatgpt.lua
+++ b/plugin/chatgpt.lua
@@ -1,4 +1,6 @@
-local chatgpt = require("chatgpt")
-
-vim.api.nvim_create_user_command("ChatGPT", chatgpt.openChat, {})
-vim.api.nvim_create_user_command("ChatGPTActAs", chatgpt.selectAwesomePrompt, {})
+vim.api.nvim_create_user_command("ChatGPT", function()
+  require("chatgpt").openChat()
+end, {})
+vim.api.nvim_create_user_command("ChatGPTActAs", function()
+  require("chatgpt").selectAwesomePrompt()
+end, {})


### PR DESCRIPTION
Hi, thank you so much for an amazing plugin!

### Issue.

One issue I have is that since the code `require("chatgpt")` in a file inside `plugin/`, this plugin is required during setup.
This prevents the possibility of lazy loading this plugin.

This PR is a quick fix to this problem which requires the plugin inside an anonymous function.

### Why I need this.

I created a script to ask for an `OPENAI_API_KEY` via `vim.ui.input` if none is specified as an environment variable. This does not work if the plugin checks for an environment variable on startup.

```lua
use({
  "jackMort/ChatGPT.nvim",
  config = function()
    local function setup_chatgpt()
      require("chatgpt").setup({
      })
    end

    if string.len(vim.env.OPENAI_API_KEY or "") < 1 then
      vim.notify(string.format("$OPENAI_API_KEY not set: %s", vim.env.OPENAI_API_KEY or "nil"), vim.log.levels["ERROR"])
      vim.ui.input({ prompt = "OPENAI_API_KEY = " }, function(input)
        if input ~= nil then
          vim.loop.os_setenv("OPENAI_API_KEY", input)
          setup_chatgpt()
        end
      end)
    else
      setup_chatgpt()
    end
  end,
  ...
})
```

Hope this gets merged :)

Best,
pysan3