### PR TITLE
Windows support

### DIFF
--- a/lua/chatgpt/flows/chat/session.lua
+++ b/lua/chatgpt/flows/chat/session.lua
@@ -5,7 +5,7 @@ local scan = require("plenary.scandir")
 local Session = classes.class()
 
 local function parse_date_time(str)
-  local year, month, day, hour, min, sec = string.match(str, "(%d+)-(%d+)-(%d+)_(%d+):(%d+):(%d+)")
+  local year, month, day, hour, min, sec = string.match(str, "(%d+)-(%d+)-(%d+)_(%d+)-(%d+)-(%d+)")
   return os.time({ year = year, month = month, day = day, hour = hour, min = min, sec = sec })
 end
 
@@ -15,7 +15,7 @@ function Session:init(opts)
   if self.filename then
     self:load()
   else
-    self.name = opts.name or os.date("%Y-%m-%d_%H:%M:%S")
+    self.name = opts.name or os.date("%Y-%m-%d_%H-%M-%S")
     self.filename = Session.get_dir():joinpath(self.name .. ".json"):absolute()
     self.conversation = {}
     self.settings = {}

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -42,7 +42,7 @@ local function write_virtual_text(bufnr, ns, line, chunks, mode)
 end
 
 M.read_config = function()
-  local file = io.open(os.getenv("HOME") .. "/" .. ".chatgpt-" .. M.type .. "-params.json", "rb")
+  local file = io.open(vim.fn.expand("~") .. "/" .. ".chatgpt-" .. M.type .. "-params.json", "rb")
   if not file then
     return nil
   end
@@ -54,7 +54,7 @@ M.read_config = function()
 end
 
 M.write_config = function(config)
-  local file, err = io.open(os.getenv("HOME") .. "/" .. ".chatgpt-" .. M.type .. "-params.json", "w")
+  local file, err = io.open(vim.fn.expand("~") .. "/" .. ".chatgpt-" .. M.type .. "-params.json", "w")
   if file ~= nil then
     local json_string = vim.json.encode(config)
     file:write(json_string)


### PR DESCRIPTION
I have fixed two problems that were occurring in Windows.

- `HOME` environmental variable is usually not set, and `USERPROFILE` is commonly used.
- `:` is forbidden for the filename.