### PR TITLE
Fix scrolling error

### DIFF
--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -52,6 +52,7 @@ local open_chat = function()
     local count = math.abs(speed)
 
     vim.api.nvim_win_call(chat_window.winid, function()
+      vim.cmd([[set modifiable]])
       vim.cmd([[normal! ]] .. count .. input)
     end)
   end


### PR DESCRIPTION
Fixes #9

Probably a better solution would be to set the chat window to be modifiable when it's created.

In the case that you wanted the chat window to be `nomodifiable`, I tried setting the the modifiable back but it seemed to break telescope event so I just left it as it is.