### PR TITLE
Code to modularise the openAI calls

### DIFF
--- a/lua/chatgpt/flows/actions/edits/init.lua
+++ b/lua/chatgpt/flows/actions/edits/init.lua
@@ -4,6 +4,19 @@ local Api = require("chatgpt.api")
 local Utils = require("chatgpt.utils")
 local Config = require("chatgpt.config")
 
+
+-- curl https://api.openai.com/v1/edits \
+--   -H "Content-Type: application/json" \
+--   -H "Authorization: Bearer $OPENAI_API_KEY" \
+--   -d '{
+--   "model": "text-davinci-edit-001",
+--   "input": "```r\ngenerate_random_points = function( base_lon, base_lat=38, max_distance = 10000, n_points=10, sample_method='hardcore',\n                                  random_seed = floor( base_lon * base_lat * 10000)) {\n\n  # for random point in the area -1...1, want to find latitude and longitude that matches these random points\n  # base_lat + random *\n\n set.seed(random_seed)\n\n lat_factor = max_distance / m_per_lat()\n lon_factor = max_distance / m_per_lon( base_lat )\n\n if (sample_method=='hardcore') {\n  beta <- n_points * 2; R = n_points / 2000\n  win <- disc(1) # Unit square for simulation\n  X1 <- rHardcore(beta, R, W = win) # Exact sampling -- beware it may run forever for some par.!\n } else {\n   # use random sampler\n }\n\nX1 %>%\n  as_tibble() %>%\n  mutate(\n         target_lon = base_lon + (x * lon_factor),\n         target_lat = base_lat + (y * lat_factor),\n         dist = distance_from( base_lon, base_lat, target_lon, target_lat)\n  ) %>%\n  filter( dist < max_distance) %>%\n  mutate(random=runif(n())) %>%\n  arrange(random) %>%\n  select(-random)\n\n}\n```\n",
+--   "instruction": "Insert a roxygen skeleton to document this R function:",
+--   "temperature": 0.7,
+--   "top_p": 1
+-- }'
+
+
 local EditAction = classes.class(BaseAction)
 
 local STRATEGY_REPLACE = "replace"
@@ -26,7 +39,6 @@ function EditAction:render_template()
     filetype = self:get_filetype(),
     input = self:get_selected_text(),
   }
-    -- require('chatgpt.log').info("data:", data)
   data = vim.tbl_extend("force", {}, data, self.variables)
   local result = self.template
   for key, value in pairs(data) do
@@ -38,9 +50,6 @@ end
 
 function EditAction:get_params()
 
-  -- local a=self:render_template()
-  -- require('chatgpt.log').info("base template:", self.template)
-  -- require('chatgpt.log').info("rendered template:", a )
   return vim.tbl_extend("force", Config.options.openai_edit_params, self.params, { input = self:render_template() })
 
 end

--- a/lua/chatgpt/flows/actions/edits/init.lua
+++ b/lua/chatgpt/flows/actions/edits/init.lua
@@ -1,0 +1,70 @@
+local classes = require("chatgpt.common.classes")
+local BaseAction = require("chatgpt.flows.actions.base")
+local Api = require("chatgpt.api")
+local Utils = require("chatgpt.utils")
+local Config = require("chatgpt.config")
+
+local EditAction = classes.class(BaseAction)
+
+local STRATEGY_REPLACE = "replace"
+local STRATEGY_DISPLAY = "display"
+local strategies = {
+  STRATEGY_REPLACE,
+  STRATEGY_DISPLAY,
+}
+
+function EditAction:init(opts)
+  self.super:init(opts)
+  self.params = opts.params or {}
+  self.template = opts.template or "{{input}}"
+  self.variables = opts.variables or {}
+  self.strategy = opts.strategy or STRATEGY_REPLACE
+end
+
+function EditAction:render_template()
+  local data = {
+    filetype = self:get_filetype(),
+    input = self:get_selected_text(),
+  }
+    -- require('chatgpt.log').info("data:", data)
+  data = vim.tbl_extend("force", {}, data, self.variables)
+  local result = self.template
+  for key, value in pairs(data) do
+    require('chatgpt.log').info("key:", key, "value:", value)
+    result = result:gsub("{{" .. key .. "}}", value)
+  end
+  return result
+end
+
+function EditAction:get_params()
+
+  -- local a=self:render_template()
+  -- require('chatgpt.log').info("base template:", self.template)
+  -- require('chatgpt.log').info("rendered template:", a )
+  return vim.tbl_extend("force", Config.options.openai_edit_params, self.params, { input = self:render_template() })
+
+end
+
+function EditAction:run()
+  vim.schedule(function()
+    self:set_loading(true)
+
+    local params = self:get_params()
+    Api.edits(params, function(answer, usage)
+      self:on_result(answer, usage)
+    end)
+  end)
+end
+
+function EditAction:on_result(answer, usage)
+  vim.schedule(function()
+    self:set_loading(false)
+
+    local bufnr = self:get_bufnr()
+    local lines = Utils.split_string_by_line(answer)
+    local start_row, start_col, end_row, end_col = self:get_visual_selection()
+    vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, lines)
+  end)
+end
+
+return EditAction

--- a/lua/chatgpt/flows/actions/init.lua
+++ b/lua/chatgpt/flows/actions/init.lua
@@ -234,7 +234,6 @@ function M.run_action(opts)
 
   local key = opts.fargs[1]
   local item = ACTIONS[key]
-  require('chatgpt.log').info( key, item)
 
 
   --

--- a/lua/chatgpt/flows/actions/init.lua
+++ b/lua/chatgpt/flows/actions/init.lua
@@ -1,7 +1,15 @@
 local M = {}
 
 local CompletionAction = require("chatgpt.flows.actions.completions")
+local EditAction = require("chatgpt.flows.actions.edits")
 local Config = require("chatgpt.config")
+
+ROXYGEN_ACTION = [[
+The following is a computer program:
+```{{filetype}}
+{{input}}
+```
+]]
 
 GRAMMAR_CORRECTION = [[
 Correct this to standard English:
@@ -24,7 +32,7 @@ WRITE_DOCSTRING = [[
 # An elaborate, high quality docstring for the above function:
 # Writing a good docstring
 
-This is an example of writing a really good docstring that follows a best practice for the given language. Attention is paid to detailing things like 
+This is an example of writing a really good docstring that follows a best practice for the given language. Attention is paid to detailing things like
 * parameter and return types (if applicable)
 * any errors that might be raised or returned, depending on the language
 
@@ -110,6 +118,17 @@ I have the following code:
 
 function M.run_action(opts)
   local ACTIONS = {
+    roxygen_edit = {
+      class = EditAction,
+      opts = {
+        template = ROXYGEN_ACTION,
+        params = {
+          model = "code-davinci-edit-001",
+          temperature = 0.5,
+          instruction="Insert a roxygen skeleton to document this function",
+        },
+      },
+    },
     grammar_correction = {
       class = CompletionAction,
       opts = {
@@ -119,7 +138,7 @@ function M.run_action(opts)
         },
       },
     },
-    translate = {
+     translate = {
       class = CompletionAction,
       opts = {
         template = TRANSLATE,
@@ -209,6 +228,8 @@ function M.run_action(opts)
 
   local key = opts.fargs[1]
   local item = ACTIONS[key]
+  require('chatgpt.log').info( key, item)
+
 
   --
   -- parse args

--- a/lua/chatgpt/flows/actions/init.lua
+++ b/lua/chatgpt/flows/actions/init.lua
@@ -5,11 +5,16 @@ local EditAction = require("chatgpt.flows.actions.edits")
 local Config = require("chatgpt.config")
 
 ROXYGEN_ACTION = [[
-The following is a computer program:
+Insert a roxygen skeleton to document this R function:
+
 ```{{filetype}}
+[insert]
+
 {{input}}
+
 ```
 ]]
+
 
 GRAMMAR_CORRECTION = [[
 Correct this to standard English:
@@ -119,13 +124,14 @@ I have the following code:
 function M.run_action(opts)
   local ACTIONS = {
     roxygen_edit = {
-      class = EditAction,
+      class = CompletionAction,
       opts = {
         template = ROXYGEN_ACTION,
+        strategy="prepend",
         params = {
-          model = "code-davinci-edit-001",
+          model = "text-davinci-003",
           temperature = 0.5,
-          instruction="Insert a roxygen skeleton to document this function",
+          max_tokens = 1024,
         },
       },
     },


### PR DESCRIPTION
Hi Lech

These might be useful for you.  There are 2 commits. The first implements functional openai edit api calls, and the second accommodates the openAI completion `insert` api.  It does the latter by taking care of splitting the input prompt into `prompt` and `suffix` chunks at the [insert] token, and implementing specialised `append` and `prepend` replacement strategies.  

My lua is pretty rusty, so I am sure you could do it more beautifully. Feel free to reject any or all of it.  Your code was easy to work with, very logical, you have a good mind for coding. 



