### PR TITLE
feat(keymaps): allow rebinding sessions pane mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ use({
     toggle_settings = "<C-o>",
     new_session = "<C-n>",
     cycle_windows = "<Tab>",
+    -- in the Sessions pane
+    select_session = "<Space>",
+    rename_session = "r",
+    delete_session = "d",
   },
 }
 ```

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -122,6 +122,9 @@ function M.defaults()
       toggle_settings = "<C-o>",
       new_session = "<C-n>",
       cycle_windows = "<Tab>",
+      select_session = "<Space>",
+      rename_session = "r",
+      delete_session = "d",
     },
     actions_paths = {},
   }

--- a/lua/chatgpt/flows/chat/sessions.lua
+++ b/lua/chatgpt/flows/chat/sessions.lua
@@ -99,15 +99,15 @@ M.get_panel = function(set_session_cb)
 
   M.panel = Popup(Config.options.sessions_window)
 
-  M.panel:map("n", "<space>", function()
+  M.panel:map("n", Config.options.keymaps.select_session, function()
     M.set_session()
   end, { noremap = true })
 
-  M.panel:map("n", "r", function()
+  M.panel:map("n", Config.options.keymaps.rename_session, function()
     M.rename_session()
   end, { noremap = true })
 
-  M.panel:map("n", "d", function()
+  M.panel:map("n", Config.options.keymaps.delete_session, function()
     M.delete_session()
   end, { noremap = true, silent = true })
 


### PR DESCRIPTION
Hi!

I added some options to rebind mappings for the session pane - specifically I wanted to rebind the "select_session" one since I have a conflict with <Space>, but added the others. Plus having them documented in the README is a bonus too!

PS. Thanks for this plugin - very cool!