### PR TITLE
Improved newline handling in interactive code edits and edit actions

### DIFF
--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -114,7 +114,7 @@ M.edit_with_instructions = function()
 
   instructions_input:map("i", Config.options.keymaps.yank_last, function()
     instructions_input.input_props.on_close()
-    vim.api.nvim_buf_set_text(bufnr, start_row-1, start_col-1, end_row-1, end_col, output)
+    vim.api.nvim_buf_set_text(bufnr, start_row - 1, start_col - 1, end_row - 1, end_col, output)
     vim.notify("Successfully applied the change!", vim.log.levels.INFO)
   end, { noremap = true })
 

--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -56,7 +56,7 @@ end
 local setup_and_mount = vim.schedule_wrap(function(lines)
   layout:mount()
   -- set input
-  vim.api.nvim_buf_set_lines(input_window.bufnr, 0, 0, false, lines)
+  vim.api.nvim_buf_set_lines(input_window.bufnr, 0, -1, false, lines)
 
   -- set input and output settings
   for _, window in ipairs({ input_window, output_window }) do
@@ -70,15 +70,7 @@ M.edit_with_instructions = function()
   bufnr = vim.api.nvim_win_get_buf(winnr)
   filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
 
-  local visual_lines, start_row, start_col, end_row, _ = Utils.get_visual_lines(bufnr)
-  if not visual_lines then
-    visual_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-    start_row = 1
-    start_col = 1
-    end_row = 0
-  end
-  -- TODO: if buffer is empty
-
+  local visual_lines, start_row, start_col, end_row, end_col = Utils.get_visual_lines(bufnr)
   local openai_params = Config.options.openai_edit_params
   local settings_panel = Settings.get_settings_panel("edits", openai_params)
   input_window = Popup(Config.options.chat_window)
@@ -99,7 +91,9 @@ M.edit_with_instructions = function()
       local params = vim.tbl_extend("keep", { input = input, instruction = instruction }, Settings.params)
       Api.edits(params, function(output_txt, usage)
         hide_progress()
-        output = Utils.split_string_by_line(output_txt)
+        local nlcount = Utils.count_newlines_at_end(input)
+        local output_txt_nlfixed = Utils.replace_newlines_at_end(output_txt, nlcount)
+        output = Utils.split_string_by_line(output_txt_nlfixed)
 
         vim.api.nvim_buf_set_lines(output_window.bufnr, 0, -1, false, output)
         display_input_suffix(usage.total_tokens)
@@ -120,7 +114,7 @@ M.edit_with_instructions = function()
 
   instructions_input:map("i", Config.options.keymaps.yank_last, function()
     instructions_input.input_props.on_close()
-    Utils.paste(bufnr, start_row, start_col, end_row, output)
+    vim.api.nvim_buf_set_text(bufnr, start_row-1, start_col-1, end_row-1, end_col, output)
     vim.notify("Successfully applied the change!", vim.log.levels.INFO)
   end, { noremap = true })
 

--- a/lua/chatgpt/flows/actions/edits/init.lua
+++ b/lua/chatgpt/flows/actions/edits/init.lua
@@ -61,9 +61,11 @@ function EditAction:on_result(answer, usage)
     self:set_loading(false)
 
     local bufnr = self:get_bufnr()
-    local lines = Utils.split_string_by_line(answer)
-    local start_row, start_col, end_row, end_col = self:get_visual_selection()
-    vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, lines)
+    local visual_lines, start_row, start_col, end_row, end_col = Utils.get_visual_lines(bufnr)
+    local nlcount = Utils.count_newlines_at_end(table.concat(visual_lines, '\n'))
+    local answer_nlfixed = Utils.replace_newlines_at_end(answer, nlcount)
+    local lines = Utils.split_string_by_line(answer_nlfixed)
+    vim.api.nvim_buf_set_text(bufnr, start_row-1, start_col-1, end_row-1, end_col, lines)
   end)
 end
 

--- a/lua/chatgpt/flows/actions/edits/init.lua
+++ b/lua/chatgpt/flows/actions/edits/init.lua
@@ -62,10 +62,10 @@ function EditAction:on_result(answer, usage)
 
     local bufnr = self:get_bufnr()
     local visual_lines, start_row, start_col, end_row, end_col = Utils.get_visual_lines(bufnr)
-    local nlcount = Utils.count_newlines_at_end(table.concat(visual_lines, '\n'))
+    local nlcount = Utils.count_newlines_at_end(table.concat(visual_lines, "\n"))
     local answer_nlfixed = Utils.replace_newlines_at_end(answer, nlcount)
     local lines = Utils.split_string_by_line(answer_nlfixed)
-    vim.api.nvim_buf_set_text(bufnr, start_row-1, start_col-1, end_row-1, end_col, lines)
+    vim.api.nvim_buf_set_text(bufnr, start_row - 1, start_col - 1, end_row - 1, end_col, lines)
   end)
 end
 

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -12,7 +12,7 @@ end
 
 function M.split_string_by_line(text)
   local lines = {}
-  for line in (text..'\n'):gmatch("(.-)\n") do
+  for line in (text .. "\n"):gmatch("(.-)\n") do
     table.insert(lines, line)
   end
   return lines
@@ -60,22 +60,22 @@ function M.get_visual_lines(bufnr)
   vim.api.nvim_feedkeys("gv", "x", false)
   vim.api.nvim_feedkeys(ESC_FEEDKEY, "n", true)
 
-  local start_row, start_col = unpack(vim.api.nvim_buf_get_mark(bufnr, '<'))
-  local end_row, end_col = unpack(vim.api.nvim_buf_get_mark(bufnr, '>'))
+  local start_row, start_col = unpack(vim.api.nvim_buf_get_mark(bufnr, "<"))
+  local end_row, end_col = unpack(vim.api.nvim_buf_get_mark(bufnr, ">"))
   local lines = vim.api.nvim_buf_get_lines(bufnr, start_row - 1, end_row, false)
 
   -- get whole buffer if there is no current/previous visual selection
   if start_row == 0 then
-      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      start_row = 1
-      start_col = 0
-      end_row = #lines
-      end_col = #lines[#lines]
+    lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    start_row = 1
+    start_col = 0
+    end_row = #lines
+    end_col = #lines[#lines]
   end
 
   -- use 1-based indexing and handle selections made in visual line mode (see :help getpos)
   start_col = start_col + 1
-  end_col = math.min(end_col, #lines[#lines]-1)+1
+  end_col = math.min(end_col, #lines[#lines] - 1) + 1
 
   -- shorten first/last line according to start_col/end_col
   lines[#lines] = lines[#lines]:sub(1, end_col)
@@ -85,13 +85,13 @@ function M.get_visual_lines(bufnr)
 end
 
 function M.count_newlines_at_end(str)
-    local start, stop = str:find("\n*$")
-    return (stop - start + 1) or 0
+  local start, stop = str:find("\n*$")
+  return (stop - start + 1) or 0
 end
 
 function M.replace_newlines_at_end(str, num)
-    local res = str:gsub("\n*$", string.rep("\n", num), 1)
-    return res
+  local res = str:gsub("\n*$", string.rep("\n", num), 1)
+  return res
 end
 
 return M


### PR DESCRIPTION
The following is from my personal fork to improve editing (interactively or via actions) of visual selections; maybe it's interesting for main? In any case, thanks for the great plugin :).

Currently, if a visual selection is edited (either interactively or via an edit action), an unwanted newline was inserted. This pull request avoids such newlines.

The changes (a) ensure that the visual selection is yanked/pasted without creating additional newlines and (b) enforce that ChatGPT's answer ends in exactly as many newlines as the visual selection. The latter is necessary since ChatGPT seems to always add a newline at the end of its answer, even if the input did not contain one. Note that this might be considered a downside of the pull request, since requests like `add 3 newlines at the end` are now ignored.

Notable changes:
* Moved the handling of a non-existing current/previous visual selection into `Utils.get_visual_lines`.
* Got rid of `Utils.get_lines`, `Utils.get_visual_start_end`, since `Utils.get_visual_lines` seems now simple enough to handle this directly.
* `Utils.end_col` is no longer needed and `Utils.paste` are also gone (replaced by a direct call to `vim.api.nvim_buf_set_text`).
* `Utils.split_string_by_line`: Previously both `some text` and `some text\n` resulted in `{"some text", ""}` (i.e., two lines). Now only the latter does, while the former yields `{"some text"}`.