### PR TITLE
Add missing setup function in config

### DIFF
--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -116,4 +116,6 @@ function M.setup(options)
   M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
 end
 
+M.setup()
+
 return M


### PR DESCRIPTION
Add missing setup function in config

This commit is to fix bug issued from https://github.com/jackMort/ChatGPT.nvim/issues/110.