### PR TITLE
feat(cycle panes): move to chat window using cycle panes

### DIFF
--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -25,6 +25,7 @@ local extmark_id = nil
 local open_chat = function()
   local chat, chat_input, layout, chat_window
   local settings_open = false
+  local active_panel = chat_input
 
   local display_input_suffix = function(suffix)
     if extmark_id then
@@ -204,6 +205,7 @@ local open_chat = function()
           vim.api.nvim_buf_set_option(settings_panel.bufnr, "modifiable", false)
           vim.api.nvim_win_set_option(settings_panel.winid, "cursorline", true)
           Utils.change_mode_to_normal()
+          active_panel = settings_panel
         end
         settings_open = not settings_open
       end, {})
@@ -222,19 +224,29 @@ local open_chat = function()
   end
 
   -- cycle panes
-  local active_panel = chat_input
-  for _, popup in ipairs({ settings_panel, sessions_panel, chat_input }) do
+  for _, popup in ipairs({ settings_panel, sessions_panel, chat_input, chat_window }) do
     for _, mode in ipairs({ "n", "i" }) do
       popup:map(mode, Config.options.keymaps.cycle_windows, function()
         if active_panel == settings_panel then
           vim.api.nvim_set_current_win(sessions_panel.winid)
           active_panel = sessions_panel
+          Utils.change_mode_to_normal()
         elseif active_panel == sessions_panel then
           vim.api.nvim_set_current_win(chat_input.winid)
           active_panel = chat_input
-        elseif settings_panel == true then
+          Utils.change_mode_to_insert()
+        elseif active_panel == chat_input then
+          vim.api.nvim_set_current_win(chat_window.winid)
+          active_panel = chat_window
+          Utils.change_mode_to_normal()
+        elseif active_panel == chat_window and settings_open == true then
           vim.api.nvim_set_current_win(settings_panel.winid)
           active_panel = settings_panel
+          Utils.change_mode_to_normal()
+        else
+          vim.api.nvim_set_current_win(chat_input.winid)
+          active_panel = chat_input
+          Utils.change_mode_to_insert()
         end
       end, {})
     end

--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -16,6 +16,7 @@ local Session = require("chatgpt.flows.chat.session")
 local Actions = require("chatgpt.flows.actions")
 local Tokens = require("chatgpt.flows.chat.tokens")
 local CodeCompletions = require("chatgpt.flows.code_completions")
+local Utils = require("chatgpt.utils")
 
 local namespace_id = vim.api.nvim_create_namespace("ChatGPTNS")
 
@@ -202,6 +203,7 @@ local open_chat = function()
           vim.api.nvim_set_current_win(settings_panel.winid)
           vim.api.nvim_buf_set_option(settings_panel.bufnr, "modifiable", false)
           vim.api.nvim_win_set_option(settings_panel.winid, "cursorline", true)
+          Utils.change_mode_to_normal()
         end
         settings_open = not settings_open
       end, {})

--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -230,7 +230,7 @@ local open_chat = function()
         elseif active_panel == sessions_panel then
           vim.api.nvim_set_current_win(chat_input.winid)
           active_panel = chat_input
-        else
+        elseif settings_panel == true then
           vim.api.nvim_set_current_win(settings_panel.winid)
           active_panel = settings_panel
         end

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -95,11 +95,11 @@ function M.replace_newlines_at_end(str, num)
 end
 
 function M.change_mode_to_normal()
-        vim.api.nvim_feedkeys(ESC_FEEDKEY, 'n', false)
+  vim.api.nvim_feedkeys(ESC_FEEDKEY, 'n', false)
 end
 
 function M.change_mode_to_insert()
-        vim.api.nvim_command('startinsert')
+  vim.api.nvim_command('startinsert')
 end
 
 return M

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -95,11 +95,11 @@ function M.replace_newlines_at_end(str, num)
 end
 
 function M.change_mode_to_normal()
-  vim.api.nvim_feedkeys(ESC_FEEDKEY, 'n', false)
+  vim.api.nvim_feedkeys(ESC_FEEDKEY, "n", false)
 end
 
 function M.change_mode_to_insert()
-  vim.api.nvim_command('startinsert')
+  vim.api.nvim_command("startinsert")
 end
 
 return M

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -98,4 +98,8 @@ function M.change_mode_to_normal()
         vim.api.nvim_feedkeys(ESC_FEEDKEY, 'n', false)
 end
 
+function M.change_mode_to_insert()
+        vim.api.nvim_command('startinsert')
+end
+
 return M

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -94,4 +94,8 @@ function M.replace_newlines_at_end(str, num)
   return res
 end
 
+function M.change_mode_to_normal()
+        vim.api.nvim_feedkeys(ESC_FEEDKEY, 'n', false)
+end
+
 return M


### PR DESCRIPTION
Hi.
Your plugin is my co-pilot when I code.
Thanks for the very cool plugin.

Now, for my use case, I wanted to partially copy the answer from chatGPT, so I made this change.
This change includes the following changes, but only adopt what you like.

change point:
- Changed not to move with cycle panes feature when settings panel does not exist
- Changed to switch to normal mode when settings panel is opened
- Added chat window as destination for cycle panes feature