### PR TITLE
fix: allow users to override defaulted api params

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -15,17 +15,17 @@ if not Api.OPENAI_API_KEY then
 end
 
 function Api.completions(custom_params, cb)
-  local params = vim.tbl_extend("keep", custom_params, Config.options.openai_params)
+  local params = vim.tbl_extend("force", custom_params, Config.options.openai_params)
   Api.make_call(Api.COMPLETIONS_URL, params, cb)
 end
 
 function Api.chat_completions(custom_params, cb)
-  local params = vim.tbl_extend("keep", custom_params, Config.options.openai_params)
+  local params = vim.tbl_extend("force", custom_params, Config.options.openai_params)
   Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
 end
 
 function Api.edits(custom_params, cb)
-  local params = vim.tbl_extend("keep", custom_params, Config.options.openai_edit_params)
+  local params = vim.tbl_extend("force", custom_params, Config.options.openai_edit_params)
   Api.make_call(Api.EDITS_URL, params, cb)
 end
 


### PR DESCRIPTION
## Description
This PR updates the behavior of parameter extension in three API functions within the ChatGPT plugin. The functions are `Api.completions`, `Api.chat_completions`, and `Api.edits`. The change involves modifying the `vim.tbl_extend()` method's first argument from `"keep"` to `"force"`.

## Changes
* In `Api.completions`, `Api.chat_completions`, and `Api.edits` functions, update the `vim.tbl_extend()` method's first argument from `"keep"` to `"force"` to ensure that user-configured OpenAI API parameters (Config.options.openai_params and Config.options.openai_edit_params) take precedence over the default parameters.