### PR TITLE
fix: Hide tokens price if it covers the input text

### DIFF
--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -18,6 +18,17 @@ function M.split_string_by_line(text)
   return lines
 end
 
+function M.max_line_length(lines)
+  local max_length = 0
+  for _, line in ipairs(lines) do
+    local str_length = string.len(line)
+    if str_length > max_length then
+      max_length = str_length
+    end
+  end
+  return max_length
+end
+
 function M.wrapText(text, maxLineLength)
   local lines = M.wrapTextToTable(text, maxLineLength)
   return table.concat(lines, "\n")


### PR DESCRIPTION
Currently, if the input text is too long, it is hidden under the tokens/price indicator, see #66.

This PR hides the tokens/price indicator when it would overlap with the input text:

### Screenshots
The tokens/price indicator is visible for short inputs.
<img width="595" alt="image" src="https://user-images.githubusercontent.com/7785912/229379491-82c3e432-24d5-452b-970e-ff35de66de6d.png">
When the line length gets too long, the indicator disappears.
<img width="594" alt="image" src="https://user-images.githubusercontent.com/7785912/229379398-bb645c9e-279e-4582-bb79-aa5c96a79c64.png">
The indicator reappears if the line length again becomes short enough.
<img width="594" alt="image" src="https://user-images.githubusercontent.com/7785912/229379411-61babbf9-5099-4c85-a61c-dbfabf6413ea.png">

Note that this PR does not target the second issue in #66 as I didn't observe it in my testing. The tokens/price indicator always shows on the line after the output text:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/7785912/229379368-5aa94a08-5c1c-4af6-88bc-988eaae7fe88.png">