### PR TITLE
feat: enable configuration of predefined chatgpt prompts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ use({
     rename_session = "r",
     delete_session = "d",
   },
+  predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
 }
 ```
 ## Usage

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -103,6 +103,7 @@ function M.defaults()
       delete_session = "d",
     },
     actions_paths = {},
+    predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
   }
   return defaults
 end

--- a/lua/chatgpt/prompts.lua
+++ b/lua/chatgpt/prompts.lua
@@ -124,9 +124,6 @@ end
 --
 
 local M = {}
-
-M.URL = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv"
-
 function M.selectAwesomePrompt(opts)
   opts = opts or {}
   pickers
@@ -139,7 +136,7 @@ function M.selectAwesomePrompt(opts)
       prompt_prefix = Config.options.chat_input.prompt,
       selection_caret = Config.options.answer_sign .. " ",
       prompt_title = "Prompt",
-      finder = finder({ url = M.URL }),
+      finder = finder({ url = Config.options.predefined_chat_gpt_prompts }),
       sorter = conf.generic_sorter(opts),
       previewer = display_content_wrapped.new({}),
       attach_mappings = function(prompt_bufnr)


### PR DESCRIPTION
To utilize CSV files other than 'awesome-chatgpt-prompts' for testing new prompts or using a customized version, the 'config.lua' file includes an option called 'predefined_chat_gpt_prompts'. This option enables the user to set their own URL instead of the previously hardcoded one.

The provided URL must adhere to the CSV file format of 'awesome-chatgpt-prompts'.