### PR TITLE
add option to close popup in normal mode; default to <Esc>

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ use({
     },
     keymaps = {
       close = { "<C-c>" },
+      close_normal = { "<Esc>" },
       yank_last = "<C-y>",
       yank_last_code = "<C-k>",
       scroll_up = "<C-u>",

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -38,6 +38,7 @@ function M.defaults()
       },
       keymaps = {
         close = { "<C-c>" },
+        close_normal = { "<Esc>" },
         yank_last = "<C-y>",
         yank_last_code = "<C-k>",
         scroll_up = "<C-u>",

--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -191,6 +191,18 @@ local open_chat = function()
     end, { noremap = true, silent = true })
   end
 
+  -- close_normal
+  local close_normal_keymaps = Config.options.keymaps.close_normal
+  if type(close_normal_keymaps) ~= "table" then
+    close_normal_keymaps = { close_normal_keymaps }
+  end
+
+  for _, keymap in ipairs(close_normal_keymaps) do
+    chat_input:map("n", keymap, function()
+      chat_input.input_props.on_close()
+    end, { noremap = true, silent = true })
+  end
+
   -- toggle settings
   for _, popup in ipairs({ settings_panel, chat_input }) do
     for _, mode in ipairs({ "n", "i" }) do

--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -192,7 +192,7 @@ local open_chat = function()
   end
 
   -- close_normal
-  local close_normal_keymaps = Config.options.keymaps.close_normal
+  local close_normal_keymaps = Config.options.chat.keymaps.close_normal
   if type(close_normal_keymaps) ~= "table" then
     close_normal_keymaps = { close_normal_keymaps }
   end


### PR DESCRIPTION
Requested feature in: https://github.com/jackMort/ChatGPT.nvim/issues/108

@jackMort can you please confirm that this change is also required in `lua/chatgpt/flows/actions/init.lua`?

Alternatively, we could allow `<Esc>` in the list of `close` bindings, but conditionally apply that to Normal mode only so that it does no mess with exiting Insert mode.

