### PR TITLE
Configure OpenAI API Key on setup

### DIFF
--- a/lua/chatgpt.lua
+++ b/lua/chatgpt.lua
@@ -1,6 +1,7 @@
 -- main module file
 local module = require("chatgpt.module")
 local config = require("chatgpt.config")
+local api = require("chatgpt.api")
 local signs = require("chatgpt.signs")
 
 local M = {}
@@ -14,6 +15,7 @@ M.setup = function(options)
   vim.api.nvim_set_hl(0, "ChatGPTCompletion", { fg = "#9399b2", italic = true, bold = false, default = true })
 
   config.setup(options)
+  api.setup(options)
   signs.setup()
 end
 

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -10,12 +10,9 @@ Api.EDITS_URL = "https://api.openai.com/v1/edits"
 
 function Api.setup(options)
   options = options or {}
-  Api.OPENAI_API_KEY = options.openai_api_key
+  Api.OPENAI_API_KEY = options.openai_api_key or os.getenv("OPENAI_API_KEY")
   if not Api.OPENAI_API_KEY then
-    Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-    if not Api.OPENAI_API_KEY then
-      error("OPENAI_API_KEY environment variable not set")
-    end
+    error("OPENAI_API_KEY environment variable not set")
   end
 end
 

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -8,10 +8,15 @@ Api.COMPLETIONS_URL = "https://api.openai.com/v1/completions"
 Api.CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
 Api.EDITS_URL = "https://api.openai.com/v1/edits"
 
--- API KEY
-Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not Api.OPENAI_API_KEY then
-  error("OPENAI_API_KEY environment variable not set")
+function Api.setup(options)
+  options = options or {}
+  Api.OPENAI_API_KEY = options.openai_api_key
+  if not Api.OPENAI_API_KEY then
+    Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    if not Api.OPENAI_API_KEY then
+      error("OPENAI_API_KEY environment variable not set")
+    end
+  end
 end
 
 function Api.completions(custom_params, cb)


### PR DESCRIPTION
Alternative to #19 that allows us to set the API Key on setup as follows:

```lua
require('chatgpt').setup({
  openai_api_key = "my-openai-secret",
})
```

With a fallback to the OPENAI_API_KEY environment variable. I personally find env vars unpleasant to work with, and I would rather have a declarative way of setting this secret.

Here's how I declare it on my dot files (secret is encrypted): https://github.com/gvolpe/nix-config/commit/a01209ad8f7cbbacbd8ac84b36d038ebda015659

---

DISCLAIMER: I have never written any Lua in my life, so happy to take any suggestions on how to improve this code :)