### PR TITLE
add close keymap to all window in ChatGPT command (#164)

### DIFF
--- a/lua/chatgpt/module.lua
+++ b/lua/chatgpt/module.lua
@@ -176,19 +176,21 @@ local open_chat = function()
   end, { noremap = true, silent = true })
 
   -- close
-  local close_keymaps = Config.options.chat.keymaps.close
-  if type(close_keymaps) ~= "table" then
-    close_keymaps = { close_keymaps }
-  end
+  for _, popup in ipairs({ settings_panel, sessions_panel, chat_input, chat_window }) do
+    local close_keymaps = Config.options.chat.keymaps.close
+    if type(close_keymaps) ~= "table" then
+      close_keymaps = { close_keymaps }
+    end
 
-  for _, keymap in ipairs(close_keymaps) do
-    chat_input:map("i", keymap, function()
-      chat_input.input_props.on_close()
-    end, { noremap = true, silent = true })
+    for _, keymap in ipairs(close_keymaps) do
+      popup:map("i", keymap, function()
+        chat_input.input_props.on_close()
+      end, { noremap = true, silent = true })
 
-    chat_input:map("n", keymap, function()
-      chat_input.input_props.on_close()
-    end, { noremap = true, silent = true })
+      popup:map("n", keymap, function()
+        chat_input.input_props.on_close()
+      end, { noremap = true, silent = true })
+    end
   end
 
   -- toggle settings


### PR DESCRIPTION
I have made a change to assign a "close window" keymap to all windows that appear with the ChatGPT command.
This change seems to be related to the following issue and pull request.

issue #164 
pull request #139 

If you respect pull request #139, you can cancel the addition of keymaps to insert mode.
```lua
  -- close
  for _, popup in ipairs({ settings_panel, sessions_panel, chat_input, chat_window }) do
    local close_keymaps = Config.options.chat.keymaps.close
    if type(close_keymaps) ~= "table" then
      close_keymaps = { close_keymaps }
    end

    for _, keymap in ipairs(close_keymaps) do
      -- popup:map("i", keymap, function()
      --   chat_input.input_props.on_close()
      -- end, { noremap = true, silent = true })

      popup:map("n", keymap, function()
        chat_input.input_props.on_close()
      end, { noremap = true, silent = true })
    end
  end

```