### PR TITLE
feat(api): added api_key_cmd configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased]
+
+## Added
+
+- OpenAI API key can now be securely provided by an external program using the
+  `api_key_cmd` configuration option. The value assigned to `api_key_cmd` must
+  be a string and is executed as is during startup. The value as stdout by the
+  executed command is used as the API key.
+
 ## [v0.1.0-alpha](https://github.com/jackMort/ChatGPT.nvim/tree/v0.1.0-alpha) - 2022-12-30
 
 [Full Changelog](https://github.com/jackMort/ChatGPT.nvim/compare/19e3f193c38dcc9be56eff71716b7ac2b582f49b...v0.1.0-alpha)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ With `ChatGPT`, you can ask questions and get answers from GPT-3 in real-time.
 ## Installation
 
 - Make sure you have `curl` installed.
-- Set environment variable called `$OPENAI_API_KEY` which you can [obtain here](https://beta.openai.com/account/api-keys).
+- Get an API key from OpenAI, which you can [obtain here](https://beta.openai.com/account/api-keys).
+
+The OpenAI API key can be provided in one of the following two ways:
+
+1. In the configuration option `api_key_cmd`, provide the path and arguments to
+   an executable that returns the API key via stdout.
+1. Setting it via an environment variable called `$OPENAI_API_KEY`.
 
 ```lua
 -- Packer
@@ -47,6 +53,7 @@ use({
 
 ```lua
 {
+  api_key_cmd = nil,
   yank_register = "+",
   edit_with_instructions = {
     diff = false,
@@ -155,6 +162,37 @@ use({
   predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
 }
 ```
+
+### Secrets Management
+
+Providing the OpenAI API key via an environment variable is dangerous, as it
+leaves the API key easily readable by any process that can access the
+environment variables of other processes. In addition, it encourages the user
+to store the credential in clear-text in a configuration file.
+
+As an alternative to providing the API key via the `OPENAI_API_KEY` environment
+variable, the user is encouraged to use the `api_key_cmd` configuration option.
+The `api_key_cmd` configuration option takes a string, which is executed at
+startup, and whose output is used as the API key.
+
+The following configuration would use 1Passwords CLI, `op`, to fetch the API key
+from the `credential` field of the `OpenAI` entry.
+
+```lua
+require("chatgpt").setup({
+    api_key_cmd = "op item get OpenAI --field credential"
+})
+```
+
+The following configuration would use GPG to decrypt a local file containing the
+API key
+
+```lua
+require("chatgpt").setup({
+    api_key_cmd = "gpg --decrypt ~/secret.txt.gpg 2>/dev/null"
+})
+```
+
 ## Usage
 
 Plugin exposes following commands:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ from the `credential` field of the `OpenAI` entry.
 
 ```lua
 require("chatgpt").setup({
-    api_key_cmd = "op item get OpenAI --field credential"
+    api_key_cmd = "op read op://private/OpenAI/credential --no-newline"
 })
 ```
 

--- a/lua/chatgpt.lua
+++ b/lua/chatgpt.lua
@@ -1,4 +1,5 @@
 -- main module file
+local api = require("chatgpt.api")
 local module = require("chatgpt.module")
 local config = require("chatgpt.config")
 local signs = require("chatgpt.signs")
@@ -14,6 +15,7 @@ M.setup = function(options)
   vim.api.nvim_set_hl(0, "ChatGPTCompletion", { fg = "#9399b2", italic = true, bold = false, default = true })
 
   config.setup(options)
+  api.setup()
   signs.setup()
 end
 

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -92,15 +92,15 @@ end
 
 function Api.setup()
   -- API KEY
-  if (Config.options.api_key_cmd == nil or Config.options.api_key_cmd == "") then
   Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-    if not Api.OPENAI_API_KEY then
+  if not Api.OPENAI_API_KEY then
+    if (Config.options.api_key_cmd ~= nil or Config.options.api_key_cmd ~= "") then
+      Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
+      if not Api.OPENAI_API_KEY then
+        error("Config 'api_key_cmd' did not return a value when executed")
+      end
+    else
       error("OPENAI_API_KEY environment variable not set")
-    end
-  else
-    Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
-    if not Api.OPENAI_API_KEY then
-      error("Config 'api_key_cmd' did not return a value when executed")
     end
   end
 end

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -8,12 +8,6 @@ Api.COMPLETIONS_URL = "https://api.openai.com/v1/completions"
 Api.CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
 Api.EDITS_URL = "https://api.openai.com/v1/edits"
 
--- API KEY
-Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not Api.OPENAI_API_KEY then
-  error("OPENAI_API_KEY environment variable not set")
-end
-
 function Api.completions(custom_params, cb)
   local params = vim.tbl_extend("keep", custom_params, Config.options.openai_params)
   Api.make_call(Api.COMPLETIONS_URL, params, cb)
@@ -93,6 +87,21 @@ end)
 function Api.close()
   if Api.job then
     job:shutdown()
+  end
+end
+
+function Api.setup()
+  -- API KEY
+  if (Config.options.api_key_cmd == nil or Config.options.api_key_cmd == "") then
+  Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    if not Api.OPENAI_API_KEY then
+      error("OPENAI_API_KEY environment variable not set")
+    end
+  else
+    Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
+    if not Api.OPENAI_API_KEY then
+      error("Config 'api_key_cmd' did not return a value when executed")
+    end
   end
 end
 

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -94,7 +94,7 @@ function Api.setup()
   -- API KEY
   Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
   if not Api.OPENAI_API_KEY then
-    if (Config.options.api_key_cmd ~= nil or Config.options.api_key_cmd ~= "") then
+    if Config.options.api_key_cmd ~= nil or Config.options.api_key_cmd ~= "" then
       Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
       if not Api.OPENAI_API_KEY then
         error("Config 'api_key_cmd' did not return a value when executed")

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -8,6 +8,7 @@ WELCOME_MESSAGE = [[
 local M = {}
 function M.defaults()
   local defaults = {
+    api_key_cmd = nil,
     yank_register = "+",
     edit_with_instructions = {
       diff = false,


### PR DESCRIPTION
This PR adds a feature to the plugin that introduces an alternative method of providing the OpenAI API key. In addition to providing the key via an `OPENAI_API_KEY` environment variable, the plugin also supports getting the API key from the output of arbitrary commands, configured via the `api_key_cmd` configuration parameter.

This allows users to securely provide the API key, without having to write it in clear-text to disk. It also prevents the API key from being readable by processes with access to the initial environment variables of neovim.

The default behaviour is to use the `OPENAI_API_KEY` environment variable, so as to not break backwards compatibility.

The README includes a couple of examples of how to use `op` or `gpg` to inject the secret into neovim.

Disclaimer: This is my first lua code since... 2005 or something, so I'm sure there's a prettier way of doing what I did here. Critique is welcome ;)

Since configuration wasn't initialized when the the `api.lua` file was being run, I had to introduce a `setup()` function to the `api.lua` file. 