### PR TITLE
fix Windows adding whitespace at the end of the key

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -103,6 +103,7 @@ function Api.setup()
       error("OPENAI_API_KEY environment variable not set")
     end
   end
+  Api.OPENAI_API_KEY = Api.OPENAI_API_KEY:gsub("%s+$", "")
 end
 
 return Api


### PR DESCRIPTION
fixes jackMort/ChatGPT.nvim#184 by guaranteeing no whitespace is to be at the end of the key string.