### PR TITLE
Make diff mode more readable.

### DIFF
--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -235,7 +235,12 @@ M.edit_with_instructions = function(output_lines, bufnr, selection, ...)
         for _, winid in ipairs({ input_window.winid, output_window.winid }) do
           vim.api.nvim_set_current_win(winid)
           if diff_mode then
+            -- set local wrap to be previous option to make it mroe readable(wrap=true is often more readable in diff mode).
+            local previous_wrap = vim.o.wrap
             vim.api.nvim_command("diffthis")
+            if vim.o.wrap ~= previous_wrap then
+              vim.o.wrap = previous_wrap
+            end
           else
             vim.api.nvim_command("diffoff")
           end


### PR DESCRIPTION
It will now keep wrap=True in diffmode instead of too long invisible lines, which is more readable now

![image](https://github.com/jackMort/ChatGPT.nvim/assets/465606/720ffe58-6c04-40c8-8be6-9d9f0beff7e0)
