### PR TITLE
fix(api): warn instead of crash in unconfigured environments

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -1,5 +1,6 @@
 local job = require("plenary.job")
 local Config = require("chatgpt.config")
+local logger = require("chatgpt.common.logger")
 
 local Api = {}
 
@@ -94,13 +95,15 @@ function Api.setup()
   -- API KEY
   Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
   if not Api.OPENAI_API_KEY then
-    if Config.options.api_key_cmd ~= nil or Config.options.api_key_cmd ~= "" then
+    if Config.options.api_key_cmd ~= nil and Config.options.api_key_cmd ~= "" then
       Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
       if not Api.OPENAI_API_KEY then
-        error("Config 'api_key_cmd' did not return a value when executed")
+        logger.warn("Config 'api_key_cmd' did not return a value when executed")
+        return
       end
     else
-      error("OPENAI_API_KEY environment variable not set")
+      logger.warn("OPENAI_API_KEY environment variable not set")
+      return
     end
   end
   Api.OPENAI_API_KEY = Api.OPENAI_API_KEY:gsub("%s+$", "")

--- a/lua/chatgpt/common/logger.lua
+++ b/lua/chatgpt/common/logger.lua
@@ -1,0 +1,4 @@
+return require("plenary.log").new({
+  plugin = "ChatGPT",
+  level = "info",
+})


### PR DESCRIPTION
Hi! There is some incorrect if statement logic in the new `api_key_cmd` setup that results in this nasty-looking error on startup in environments without an API key (this can happen in a variety of situations like editing your [kitty](https://github.com/kovidgoyal/kitty) settings in this example screenshot)

<img width="1807" alt="Screenshot 2023-05-26 at 8 45 37 AM" src="https://github.com/jackMort/ChatGPT.nvim/assets/51095001/f151654f-671c-4fcb-b49d-edbdae3cbbfe">

This pr fixes the if statement logic, and switches to a more pleasant warning if this kind of thing ever happens:

<img width="1802" alt="Screenshot 2023-05-26 at 8 45 13 AM" src="https://github.com/jackMort/ChatGPT.nvim/assets/51095001/6ac37af5-9bfd-4e9d-a6ea-1b730d5254ff">
