### PR TITLE
Add in a new setup option for asynchronously loading API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ use({
 ```lua
 {
     api_key_cmd = nil,
-    async_api_key_cmd = nil,
     yank_register = "+",
     edit_with_instructions = {
       diff = false,
@@ -220,15 +219,6 @@ API key
 ```lua
 require("chatgpt").setup({
     api_key_cmd = "gpg --decrypt ~/secret.txt.gpg 2>/dev/null"
-})
-```
-
-alternatively, you can choose to run this command asynchronously by using the
-`async_api_key_cmd` option instead.
-
-```lua
-require("chatgpt").setup({
-    async_api_key_cmd = "op read op://private/OpenAI/credential --no-newline"
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ use({
 ```lua
 {
     api_key_cmd = nil,
+    async_api_key_cmd = nil,
     yank_register = "+",
     edit_with_instructions = {
       diff = false,
@@ -219,6 +220,15 @@ API key
 ```lua
 require("chatgpt").setup({
     api_key_cmd = "gpg --decrypt ~/secret.txt.gpg 2>/dev/null"
+})
+```
+
+alternatively, you can choose to run this command asynchronously by using the
+`async_api_key_cmd` option instead.
+
+```lua
+require("chatgpt").setup({
+    async_api_key_cmd = "op read op://private/OpenAI/credential --no-newline"
 })
 ```
 

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -99,33 +99,29 @@ local splitCommandIntoTable = function(command)
   return cmd
 end
 
-local loadAsyncApiKey = function(command)
+local loadApiKey = function(command)
   local cmd = splitCommandIntoTable(command)
   -- API KEY
-  job:new({
-    command = cmd[1],
-    args = vim.list_slice(cmd, 2, #cmd),
-    on_exit = function(j, exit_code)
-      if exit_code ~= 0 then
-        logger.warn("Config 'api_key_cmd' did not return a value when executed")
-        return
-      end
-      Api.OPENAI_API_KEY = j:result()[1]:gsub("%s+$", "")
-    end,
-  }):start()
+  job
+    :new({
+      command = cmd[1],
+      args = vim.list_slice(cmd, 2, #cmd),
+      on_exit = function(j, exit_code)
+        if exit_code ~= 0 then
+          logger.warn("Config 'api_key_cmd' did not return a value when executed")
+          return
+        end
+        Api.OPENAI_API_KEY = j:result()[1]:gsub("%s+$", "")
+      end,
+    })
+    :start()
 end
 
 function Api.setup()
   Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
   if not Api.OPENAI_API_KEY then
     if Config.options.api_key_cmd ~= nil and Config.options.api_key_cmd ~= "" then
-      Api.OPENAI_API_KEY = vim.fn.system(Config.options.api_key_cmd)
-      if not Api.OPENAI_API_KEY then
-        logger.warn("Config 'api_key_cmd' did not return a value when executed")
-        return
-      end
-    elseif Config.options.async_api_key_cmd ~= nil and Config.options.async_api_key_cmd ~= "" then
-      loadAsyncApiKey(Config.options.async_api_key_cmd)
+      loadApiKey(Config.options.api_key_cmd)
     else
       logger.warn("OPENAI_API_KEY environment variable not set")
       return

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -131,7 +131,9 @@ function Api.setup()
       return
     end
   end
-  Api.OPENAI_API_KEY = Api.OPENAI_API_KEY:gsub("%s+$", "")
+  if Api.OPENAI_API_KEY ~=nil and Api.OPENAI_API_KEY ~= "" then
+    Api.OPENAI_API_KEY = Api.OPENAI_API_KEY:gsub("%s+$", "")
+  end
 end
 
 return Api

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -91,8 +91,31 @@ function Api.close()
   end
 end
 
-function Api.setup()
+local splitCommandIntoTable = function(command)
+  local cmd = {}
+  for word in command:gmatch("%S+") do
+    table.insert(cmd, word)
+  end
+  return cmd
+end
+
+local loadAsyncApiKey = function(command)
+  local cmd = splitCommandIntoTable(command)
   -- API KEY
+  job:new({
+    command = cmd[1],
+    args = vim.list_slice(cmd, 2, #cmd),
+    on_exit = function(j, exit_code)
+      if exit_code ~= 0 then
+        logger.warn("Config 'api_key_cmd' did not return a value when executed")
+        return
+      end
+      Api.OPENAI_API_KEY = j:result()[1]:gsub("%s+$", "")
+    end,
+  }):start()
+end
+
+function Api.setup()
   Api.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
   if not Api.OPENAI_API_KEY then
     if Config.options.api_key_cmd ~= nil and Config.options.api_key_cmd ~= "" then
@@ -101,6 +124,8 @@ function Api.setup()
         logger.warn("Config 'api_key_cmd' did not return a value when executed")
         return
       end
+    elseif Config.options.async_api_key_cmd ~= nil and Config.options.async_api_key_cmd ~= "" then
+      loadAsyncApiKey(Config.options.async_api_key_cmd)
     else
       logger.warn("OPENAI_API_KEY environment variable not set")
       return

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -127,7 +127,7 @@ function Api.setup()
       return
     end
   end
-  if Api.OPENAI_API_KEY ~=nil and Api.OPENAI_API_KEY ~= "" then
+  if Api.OPENAI_API_KEY ~= nil and Api.OPENAI_API_KEY ~= "" then
     Api.OPENAI_API_KEY = Api.OPENAI_API_KEY:gsub("%s+$", "")
   end
 end


### PR DESCRIPTION
The setup option of `api_key_cmd` is great, but it's performed synchronously. As I use a password store backed by a Yubikey, this can cause a significant delay when opening up Neovim.

In order to solve this, I've added a new setup option of `async_api_key_cmd` which uses plenary.job to asynchronously load the API key. For me, this improves the performance of opening up neovim and makes the plugin usable again. 

There are some caveats with this, however.

You can only specify a command that follows the following format:

```
<cmd> <args>
```

Anything with piping, won't work. i.e.

```
<cmd> <args> | <cmd2>
```

Therefore, I opted to add a new setup configuration value, to ensure this does not break existing configurations. There may be a way to improve on this so that any command can be performed by the plenary job module.