### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ API key
 
 ```lua
 require("chatgpt").setup({
-    api_key_cmd = "gpg --decrypt ~/secret.txt.gpg 2>/dev/null"
+    api_key_cmd = "gpg --decrypt ~/secret.txt.gpg"
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ The following configuration would use GPG to decrypt a local file containing the
 API key
 
 ```lua
+local home = vim.fn.expand("$HOME")
 require("chatgpt").setup({
-    api_key_cmd = "gpg --decrypt ~/secret.txt.gpg"
+    api_key_cmd = "gpg --decrypt " .. home .. "/secret.txt.gpg"
 })
 ```
 


### PR DESCRIPTION
` 2>/dev/null`  is not necessary in the latest version.w

In my environment, it will result in `Config 'api_key_cmd' did not return a value when executed` if ` 2>/dev/null` is not removed.