### PR TITLE
Fix a typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ model.
 ![preview image](https://github.com/jackMort/ChatGPT.nvim/blob/media/preview-3.png?raw=true)
 
 #### `ChatGPTEditWithInstructions`
-`ChatGPTEditWithInstructions` command which opens interactive window to edit selected text or whole window using the `code-davinci-edit-002` model (GPT 3.5 fine-tuned for coding).
+`ChatGPTEditWithInstructions` command which opens interactive window to edit selected text or whole window using the `code-davinci-edit-001` model (GPT 3.5 fine-tuned for coding).
 
 You can map it using the Lua API, e.g. using `which-key.nvim`:
 ```lua


### PR DESCRIPTION
`code-davinci-edit-002` seems do no exist. And `lua/chatgpt/config.lua` shows that the model is `code-davinci-edit-001`.