### PR TITLE
Remove Edit api calls due to OpenAI api change 

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -73,7 +73,13 @@ end
 
 function Api.edits(custom_params, cb)
   local params = vim.tbl_extend("keep", custom_params, Config.options.openai_edit_params)
-  Api.make_call(Api.EDITS_URL, params, cb)
+  if params.model == "text-davinci-edit-001" or params.model == "code-davinci-edit-001" then 
+	vim.notify("Edit models are deprecated", vim.log.levels.WARN)
+  	Api.make_call(Api.EDITS_URL, params, cb)
+	return
+  end
+
+  Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
 end
 
 function Api.make_call(url, params, cb)
@@ -85,6 +91,7 @@ function Api.make_call(url, params, cb)
   end
   f:write(vim.fn.json_encode(params))
   f:close()
+  print()
   Api.job = job
     :new({
       command = "curl",

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -140,12 +140,12 @@ function M.defaults()
       top_p = 1,
       n = 1,
     },
-    openai_edit_params = {
-      model = "code-davinci-edit-001",
-      temperature = 0,
-      top_p = 1,
-      n = 1,
-    },
+    -- openai_edit_params = {
+    --   model = "code-davinci-edit-001",
+    --   temperature = 0,
+    --   top_p = 1,
+    --   n = 1,
+    -- },
     actions_paths = {},
     show_quickfixes_cmd = "Trouble quickfix",
     predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
@@ -159,6 +159,9 @@ M.namespace_id = vim.api.nvim_create_namespace("ChatGPTNS")
 
 function M.setup(options)
   options = options or {}
+  if options.openai_edit_params ~= nil then 
+	vim.notify("since edit api is deprecated, remove the \"openai_edit_params\" field to remove this notice", vim.log.levels.WARN)
+  end
   M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
 end
 


### PR DESCRIPTION
Here is what i changed:
1. Remove the "openai_edit_params" in default config and raise a deprecated warning if applied in user config
2. changed api.lua to call the chat completion api as in this page "https://openai.com/blog/gpt-4-api-general-availability"
3. changed code_edits to as they showed on that page too