### PR TITLE
Edit with instructions using OpenAI functions

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -73,7 +73,13 @@ end
 
 function Api.edits(custom_params, cb)
   local params = vim.tbl_extend("keep", custom_params, Config.options.openai_edit_params)
-  Api.make_call(Api.EDITS_URL, params, cb)
+  if params.model == "text-davinci-edit-001" or params.model == "code-davinci-edit-001" then 
+	vim.notify("Edit models are deprecated", vim.log.levels.WARN)
+  	Api.make_call(Api.EDITS_URL, params, cb)
+	return
+  end
+
+  Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
 end
 
 function Api.make_call(url, params, cb)
@@ -85,6 +91,7 @@ function Api.make_call(url, params, cb)
   end
   f:write(vim.fn.json_encode(params))
   f:close()
+  print()
   Api.job = job
     :new({
       command = "curl",

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -73,10 +73,10 @@ end
 
 function Api.edits(custom_params, cb)
   local params = vim.tbl_extend("keep", custom_params, Config.options.openai_edit_params)
-  if params.model == "text-davinci-edit-001" or params.model == "code-davinci-edit-001" then 
-	vim.notify("Edit models are deprecated", vim.log.levels.WARN)
-  	Api.make_call(Api.EDITS_URL, params, cb)
-	return
+  if params.model == "text-davinci-edit-001" or params.model == "code-davinci-edit-001" then
+    vim.notify("Edit models are deprecated", vim.log.levels.WARN)
+    Api.make_call(Api.EDITS_URL, params, cb)
+    return
   end
 
   Api.make_call(Api.CHAT_COMPLETIONS_URL, params, cb)
@@ -91,7 +91,6 @@ function Api.make_call(url, params, cb)
   end
   f:write(vim.fn.json_encode(params))
   f:close()
-  print()
   Api.job = job
     :new({
       command = "curl",

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -126,9 +126,15 @@ Api.handle_response = vim.schedule_wrap(function(response, exit_code, cb)
   else
     local message = json.choices[1].message
     if message ~= nil then
-      local response_text = json.choices[1].message.content
-      if type(response_text) == "string" and response_text ~= "" then
-        cb(response_text, json.usage)
+      local message_response
+      local first_message = json.choices[1].message
+      if first_message.function_call then
+        message_response = vim.fn.json_decode(first_message.function_call.arguments)
+      else
+        message_response = first_message.content
+      end
+      if (type(message_response) == "string" and message_response ~= "") or type(message_response) == "table" then
+        cb(message_response, json.usage)
       else
         cb("...")
       end

--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -15,15 +15,15 @@ local Settings = require("chatgpt.settings")
 local messages = {
 	{
 		role = "system",
-		content = "Apply the change requested by the user to the code. code only, you are acting like a editor, just output things requested",
+		content = "You are an AI code editor, capable of understanding and editing code from prompts in various languages. Please make the requested changes to the following code, regardless of the input language. Return only the modified code, with no additional comments or outputs.",
 	},
 	{
-		role = "user",
+		role = "system",
 		content = "",
 	},
 	{
 		role = "user",
-		content = "",
+		content = "Only return the edited code, with no explanations or comments.",
 	}
 }
 
@@ -121,7 +121,7 @@ M.edit_with_instructions = function(output_lines, bufnr, selection, ...)
 	  -- deep copy the messages so it could be reused (maybe not needed)
 	  local msg = vim.deepcopy(messages)
 	  msg[2].content = input
-	  msg[3].content = instruction
+	  msg[3].content = instruction .. msg[3].content
       local params = vim.tbl_extend("keep", { messages = msg }, Settings.params)
       Api.edits(params, function(output_txt, usage)
         hide_progress()

--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -10,12 +10,38 @@ local Utils = require("chatgpt.utils")
 local Spinner = require("chatgpt.spinner")
 local Settings = require("chatgpt.settings")
 
+EDIT_FUNCTION_ARGUMENTS = {
+  function_call = {
+    name = 'apply_code_changes'
+  },
+  functions = {
+    {
+      name = 'apply_code_changes',
+      description = 'Apply changes to the provided code based on the provided instructions, and briefly describe the edits.',
+      parameters = {
+        type = 'object',
+        properties = {
+          changed_code = {
+            type = 'string',
+            description = 'The changed code.'
+          },
+          applied_changes = {
+            type = 'string',
+            description = 'Brief descriptions of the edits applied to the original code, formatted as a bullet list.'
+          }
+        }
+      },
+      required = {'changed_code', 'applied_changes'},
+    }
+  }
+}
+
 -- https://openai.com/blog/gpt-4-api-general-availability
 local build_edit_messages = function(input, instructions)
   local messages = {
     {
       role = "system",
-      content = "Apply the change requested by the user to the code. Output ONLY the changed code. DO NOT wrap the code in a formatting block. DO NOT provide other text or explanation.",
+      content = "Apply the changes requested by the user to the code. Output ONLY the changed code and a brief description of the edits. DO NOT wrap the code in a formatting block. DO NOT provide other text or explanation.",
     },
     {
       role = "user",
@@ -104,6 +130,7 @@ M.edit_with_instructions = function(output_lines, bufnr, selection, ...)
     visual_lines, start_row, start_col, end_row, end_col = unpack(selection)
   end
   local openai_params = Config.options.openai_edit_params
+  local use_functions_for_edits = Config.options.use_openai_functions_for_edits
   local settings_panel = Settings.get_settings_panel("edits", openai_params)
   input_window = Popup(Config.options.popup_window)
   output_window = Popup(Config.options.popup_window)
@@ -121,15 +148,25 @@ M.edit_with_instructions = function(output_lines, bufnr, selection, ...)
 
       local input = table.concat(vim.api.nvim_buf_get_lines(input_window.bufnr, 0, -1, false), "\n")
       local messages = build_edit_messages(input, instruction)
-      local params = vim.tbl_extend("keep", { messages = messages }, Settings.params)
-      Api.edits(params, function(output_txt, usage)
+      local function_params = use_functions_for_edits and EDIT_FUNCTION_ARGUMENTS or {}
+      local params = vim.tbl_extend("keep", { messages = messages }, Settings.params, function_params)
+      Api.edits(params, function(response, usage)
         hide_progress()
         local nlcount = Utils.count_newlines_at_end(input)
+        local output_txt = response
+        if use_functions_for_edits then
+          output_txt = Utils.match_indentation(input, response.changed_code)
+          if response.applied_changes then
+            vim.notify(response.applied_changes, vim.log.levels.INFO)
+          end
+        end
         local output_txt_nlfixed = Utils.replace_newlines_at_end(output_txt, nlcount)
         output = Utils.split_string_by_line(output_txt_nlfixed)
 
         vim.api.nvim_buf_set_lines(output_window.bufnr, 0, -1, false, output)
-        display_input_suffix(usage.total_tokens)
+        if usage then
+          display_input_suffix(usage.total_tokens)
+        end
       end)
     end),
   })

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -140,12 +140,14 @@ function M.defaults()
       top_p = 1,
       n = 1,
     },
-    -- openai_edit_params = {
-    --   model = "code-davinci-edit-001",
-    --   temperature = 0,
-    --   top_p = 1,
-    --   n = 1,
-    -- },
+    openai_edit_params = {
+      model = "gpt-3.5-turbo",
+      frequency_penalty = 0,
+      presence_penalty = 0,
+      temperature = 0,
+      top_p = 1,
+      n = 1,
+    },
     actions_paths = {},
     show_quickfixes_cmd = "Trouble quickfix",
     predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
@@ -159,9 +161,6 @@ M.namespace_id = vim.api.nvim_create_namespace("ChatGPTNS")
 
 function M.setup(options)
   options = options or {}
-  if options.openai_edit_params ~= nil then 
-	vim.notify("since edit api is deprecated, remove the \"openai_edit_params\" field to remove this notice", vim.log.levels.WARN)
-  end
   M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
 end
 

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -148,6 +148,7 @@ function M.defaults()
       top_p = 1,
       n = 1,
     },
+    use_openai_functions_for_edits = false,
     actions_paths = {},
     show_quickfixes_cmd = "Trouble quickfix",
     predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -140,12 +140,12 @@ function M.defaults()
       top_p = 1,
       n = 1,
     },
-    openai_edit_params = {
-      model = "code-davinci-edit-001",
-      temperature = 0,
-      top_p = 1,
-      n = 1,
-    },
+    -- openai_edit_params = {
+    --   model = "code-davinci-edit-001",
+    --   temperature = 0,
+    --   top_p = 1,
+    --   n = 1,
+    -- },
     actions_paths = {},
     show_quickfixes_cmd = "Trouble quickfix",
     predefined_chat_gpt_prompts = "https://raw.githubusercontent.com/f/awesome-chatgpt-prompts/main/prompts.csv",
@@ -159,6 +159,9 @@ M.namespace_id = vim.api.nvim_create_namespace("ChatGPTNS")
 
 function M.setup(options)
   options = options or {}
+  if options.openai_edit_params ~= nil then 
+	vim.notify("since edit api is deprecated, remove the \"openai_edit_params\" field to remove this notice", vim.log.levels.WARN)
+  end
   M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
 end
 

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -129,4 +129,21 @@ function M.calculate_percentage_width(percentage)
   return width
 end
 
+function M.match_indentation(input, output)
+    local input_indent = input:match("\n*([^\n]*)"):match("^(%s*)")
+    local output_indent = output:match("\n*([^\n]*)"):match("^(%s*)")
+    if input_indent == output_indent then
+        return output
+    end
+    local lines = {}
+    for line in output:gmatch("([^\n]*\n?)") do
+        if line:match("^%s*$") then
+            table.insert(lines, line)
+        else
+            table.insert(lines, input_indent .. line)
+        end
+    end
+    return table.concat(lines)
+end
+
 return M


### PR DESCRIPTION
This is a *mostly* working solution, which greatly expands upon the work started at https://github.com/jackMort/ChatGPT.nvim/pull/249

This PR implements a cleaner version of using GPT 3.5/4 directly, and also has support for leveraging OpenAI functions if the `use_openai_functions_for_edits` config option is set to `true` (default is `false`).

On the whole, using OpenAI functions works well, however, there are some edge cases where parsing out the function arguments throws JSON parsing errors -- I tried for awhile to figure out the escaping magic to get it to behave in all cases, but so far have not had luck. Perhaps another set of eyes could help with that...