### PR TITLE
Limit Visible Lines in Input Popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ use({
       },
       submit = "<C-Enter>",
       submit_n = "<Enter>",
+      max_visible_lines = nil
     },
     settings_window = {
       border = {

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ use({
       },
       submit = "<C-Enter>",
       submit_n = "<Enter>",
-      max_visible_lines = nil
+      max_visible_lines = 20
     },
     settings_window = {
       border = {

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -119,7 +119,7 @@ function M.defaults()
       },
       submit = "<C-Enter>",
       submit_n = "<Enter>",
-      max_visible_lines = nil
+      max_visible_lines = 20
     },
     settings_window = {
       border = {

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -119,7 +119,7 @@ function M.defaults()
       },
       submit = "<C-Enter>",
       submit_n = "<Enter>",
-      max_visible_lines = 20
+      max_visible_lines = 20,
     },
     settings_window = {
       border = {

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -119,6 +119,7 @@ function M.defaults()
       },
       submit = "<C-Enter>",
       submit_n = "<Enter>",
+      max_visible_lines = nil
     },
     settings_window = {
       border = {

--- a/lua/chatgpt/input.lua
+++ b/lua/chatgpt/input.lua
@@ -97,6 +97,10 @@ function Input:init(popup_options, options)
   if options.on_change then
     props.on_change = function()
       local lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
+      local max_lines = Config.options.popup_input.max_visible_lines  -- Set the maximum number of lines here
+      if max_lines ~= nil and #lines > max_lines then
+        lines = {unpack(lines, 1, max_lines)}  -- Only keep the first max_lines lines
+      end
       if #lines == 1 then
         vim.fn.sign_place(0, "my_group", "singleprompt_sign", self.bufnr, { lnum = 1, priority = 10 })
       else

--- a/lua/chatgpt/input.lua
+++ b/lua/chatgpt/input.lua
@@ -97,9 +97,9 @@ function Input:init(popup_options, options)
   if options.on_change then
     props.on_change = function()
       local lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
-      local max_lines = Config.options.popup_input.max_visible_lines  -- Set the maximum number of lines here
+      local max_lines = Config.options.popup_input.max_visible_lines -- Set the maximum number of lines here
       if max_lines ~= nil and #lines > max_lines then
-        lines = {unpack(lines, 1, max_lines)}  -- Only keep the first max_lines lines
+        lines = { unpack(lines, 1, max_lines) } -- Only keep the first max_lines lines
       end
       if #lines == 1 then
         vim.fn.sign_place(0, "my_group", "singleprompt_sign", self.bufnr, { lnum = 1, priority = 10 })


### PR DESCRIPTION
This pull request introduces a fix for the issue where long prompts would overflow the screen. By limiting the number of visible lines in the input popup, we prevent overflow and ensure that the user interface remains clean and accessible. This enhancement improves the overall user experience, particularly when dealing with large amounts of text. It is configurable so users will be able to choose if this feature is enabled.