### PR TITLE
fix: permit ChatGPTEditWithInstructions to work with visual linewise selection

### DIFF
--- a/plugin/chatgpt.lua
+++ b/plugin/chatgpt.lua
@@ -8,7 +8,9 @@ end, {})
 
 vim.api.nvim_create_user_command("ChatGPTEditWithInstructions", function()
   require("chatgpt").edit_with_instructions()
-end, {})
+end, {
+  range = true,
+})
 
 vim.api.nvim_create_user_command("ChatGPTRun", function(opts)
   require("chatgpt").run_action(opts)


### PR DESCRIPTION
I think this may have been accidentally closed: https://github.com/jackMort/ChatGPT.nvim/pull/58

This allows visual linewise selection and function call without any obvious downside.