### PR TITLE
Add note to README about api_key_cmd and spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ require("chatgpt").setup({
 })
 ```
 
+Note that the `api_key_cmd` arguments are split by whitespace. If you need whitespace inside an argument (for example to reference a path with spaces), you can wrap it in a separate script and use that the executable.
+
 ## Usage
 
 Plugin exposes following commands:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ require("chatgpt").setup({
 })
 ```
 
-Note that the `api_key_cmd` arguments are split by whitespace. If you need whitespace inside an argument (for example to reference a path with spaces), you can wrap it in a separate script and use that the executable.
+Note that the `api_key_cmd` arguments are split by whitespace. If you need whitespace inside an argument (for example to reference a path with spaces), you can wrap it in a separate script.
 
 ## Usage
 


### PR DESCRIPTION
Discovered that you can't use spaces inside arguments passed to `api_key_cmd` since the job command is splitting arguments on whitespace.

Added it as a note to the README in an attempt to save the next person the 10 minutes of debugging it took me to figure this out.

## Test plan

Checked the preview of the readme. Otherwise rely on spell checking.