### PR TITLE
feat: add config options to replace all nerd font icons

### DIFF
--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -78,9 +78,9 @@ local display_input_suffix = function(suffix)
 
   extmark_id = vim.api.nvim_buf_set_extmark(instructions_input.bufnr, namespace_id, 0, -1, {
     virt_text = {
-      { "", "ChatGPTTotalTokensBorder" },
+      { Config.options.chat.border_left_sign, "ChatGPTTotalTokensBorder" },
       { "" .. suffix, "ChatGPTTotalTokens" },
-      { "", "ChatGPTTotalTokensBorder" },
+      { Config.options.chat.border_right_sign, "ChatGPTTotalTokensBorder" },
       { " ", "" },
     },
     virt_text_pos = "right_align",

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -26,8 +26,13 @@ function M.defaults()
       loading_text = "Loading, please wait ...",
       question_sign = "", -- 🙂
       answer_sign = "ﮧ", -- 🤖
+      border_left_sign = "",
+      border_right_sign = "",
       max_line_length = 120,
       sessions_window = {
+        active_sign = "  ",
+        inactive_sign = "  ",
+        current_line_sign = "",
         border = {
           style = "rounded",
           text = {
@@ -123,6 +128,7 @@ function M.defaults()
       max_visible_lines = 20,
     },
     settings_window = {
+      setting_sign = "  ",
       border = {
         style = "rounded",
         text = {

--- a/lua/chatgpt/flows/actions/base.lua
+++ b/lua/chatgpt/flows/actions/base.lua
@@ -2,6 +2,7 @@ local classes = require("chatgpt.common.classes")
 local Signs = require("chatgpt.signs")
 local Spinner = require("chatgpt.spinner")
 local Utils = require("chatgpt.utils")
+local Config = require("chatgpt.config")
 
 local BaseAction = classes.class()
 
@@ -76,9 +77,9 @@ function BaseAction:render_spinner(state)
       start_row, start_col = get_selection_center(start_row, start_col, end_row, end_col)
       self.extmark_id = vim.api.nvim_buf_set_extmark(bufnr, namespace_id, start_row, 0, {
         virt_text = {
-          { "", "ChatGPTTotalTokensBorder" },
+          { Config.options.chat.border_left_sign, "ChatGPTTotalTokensBorder" },
           { state .. " Processing, please wait ...", "ChatGPTTotalTokens" },
-          { "", "ChatGPTTotalTokensBorder" },
+          { Config.options.chat.border_right_sign, "ChatGPTTotalTokensBorder" },
           { " ", "" },
         },
         virt_text_pos = "eol",

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -93,12 +93,12 @@ function Chat:render_role()
 
   self.role_extmark_id = vim.api.nvim_buf_set_extmark(self.chat_input.bufnr, Config.namespace_id, 0, 0, {
     virt_text = {
-      { "", "ChatGPTTotalTokensBorder" },
+      { Config.options.chat.border_left_sign, "ChatGPTTotalTokensBorder" },
       {
         string.upper(self.role),
         "ChatGPTTotalTokens",
       },
-      { "", "ChatGPTTotalTokensBorder" },
+      { Config.options.chat.border_right_sign, "ChatGPTTotalTokensBorder" },
       { " " },
     },
     virt_text_pos = "right_align",
@@ -438,12 +438,12 @@ function Chat:renderLastMessage()
       self.messages[self.selectedIndex].extmark_id =
         vim.api.nvim_buf_set_extmark(self.chat_window.bufnr, Config.namespace_id, msg.end_line + 1, 0, {
           virt_text = {
-            { "", "ChatGPTTotalTokensBorder" },
+            { Config.options.chat.border_left_sign, "ChatGPTTotalTokensBorder" },
             {
               "TOKENS: " .. msg.usage.total_tokens,
               "ChatGPTTotalTokens",
             },
-            { "", "ChatGPTTotalTokensBorder" },
+            { Config.options.chat.border_right_sign, "ChatGPTTotalTokensBorder" },
             { " ", "" },
           },
           virt_text_pos = "right_align",
@@ -554,9 +554,9 @@ function Chat:display_input_suffix(suffix)
   if suffix then
     self.extmark_id = vim.api.nvim_buf_set_extmark(self.chat_input.bufnr, Config.namespace_id, 0, -1, {
       virt_text = {
-        { "", "ChatGPTTotalTokensBorder" },
+        { Config.options.chat.border_left_sign, "ChatGPTTotalTokensBorder" },
         { "" .. suffix, "ChatGPTTotalTokens" },
-        { "", "ChatGPTTotalTokensBorder" },
+        { Config.options.chat.border_right_sign, "ChatGPTTotalTokensBorder" },
         { " ", "" },
       },
       virt_text_pos = "right_align",

--- a/lua/chatgpt/flows/chat/sessions.lua
+++ b/lua/chatgpt/flows/chat/sessions.lua
@@ -56,11 +56,12 @@ M.render_list = function()
 
   local details = {}
   for i, session in pairs(M.sessions) do
-    local icon = i == M.active_line and "  " or "  "
+    local icon = i == M.active_line and Config.options.chat.sessions_window.active_sign
+      or Config.options.chat.sessions_window.inactive_sign
     local cls = i == M.active_line and "ErrorMsg" or "Comment"
     local name = Utils.trimText(session.name, 30)
     local vt = {
-      { (M.current_line == i and "" or " ") .. icon .. name, cls },
+      { (M.current_line == i and Config.options.chat.sessions_window.current_line_sign or " ") .. icon .. name, cls },
     }
     table.insert(details, vt)
   end

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -78,7 +78,7 @@ M.get_settings_panel = function(type, default_params)
   for _, key in pairs(params_order) do
     if M.params[key] ~= nil then
       local vt = {
-        { "  " .. key .. ": ", "ErrorMsg" },
+        { Config.options.settings_window.setting_sign .. key .. ": ", "ErrorMsg" },
         { M.params[key] .. "", "Identifier" },
       }
       table.insert(details, vt)
@@ -112,7 +112,8 @@ M.get_settings_panel = function(type, default_params)
     M.open_edit_property_input(key, value, row, function(new_value)
       M.params[key] = params_validators[key](new_value)
       local vt = {
-        { "  " .. key .. ": ", "ErrorMsg" },
+
+        { Config.options.settings_window.setting_sign .. key .. ": ", "ErrorMsg" },
         { M.params[key] .. "", "Identifier" },
       }
       vim.api.nvim_buf_del_extmark(M.panel.bufnr, namespace_id, M.vts[row - 1])
@@ -152,7 +153,7 @@ M.open_edit_property_input = function(key, value, row, cb)
       winhighlight = "Normal:Normal,FloatBorder:Normal",
     },
   }, {
-    prompt = "  " .. key .. ": ",
+    prompt = Config.options.popup_input.prompt .. key .. ": ",
     default_value = "" .. value,
     on_submit = cb,
   })


### PR DESCRIPTION
These new config options will resolve #187 by allowing users to change all of the nerd font icons. It is an alternative to #295 that maintains backwards compatibility for people still using old versions of the patched fonts.


Let me know if I missed any icons, or if you would prefer different names for the config options. Thanks!