### PR TITLE
Fix #303: curl error

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -189,12 +189,14 @@ local function loadConfigFromCommand(command, optionName, callback, defaultValue
     :start()
 end
 
-local function loadConfigFromEnv(envName, configName)
+local function loadConfigFromEnv(envName, configName, callback)
   local variable = os.getenv(envName)
   if not variable then
     return
   end
-  Api[configName] = variable:gsub("%s+$", "")
+  local value = variable:gsub("%s+$", "")
+  Api[configName] = value
+  callback(value)
 end
 
 local function loadApiHost(envName, configName, optionName, callback, defaultValue)
@@ -211,7 +213,7 @@ local function loadApiHost(envName, configName, optionName, callback, defaultVal
 end
 
 local function loadApiKey(envName, configName, optionName, callback, defaultValue)
-  loadConfigFromEnv(envName, configName)
+  loadConfigFromEnv(envName, configName, callback)
   if not Api[configName] then
     if Config.options[optionName] ~= nil and Config.options[optionName] ~= "" then
       loadConfigFromCommand(Config.options[optionName], optionName, callback, defaultValue)


### PR DESCRIPTION
curl: option -H: requires parameter error

Seems to be related to this change here from this PR that tries to add support for AZURE environment variables as well.

https://github.com/jackMort/ChatGPT.nvim/pull/293/files

Api.AUTHORIZATION_HEADER is nil in Api.chat_completions...

The callback passed to loadApiKey is not guaranteed to be called in the case that the environment variable for OPENAI_API_KEY exists.

```lua
local function loadConfigFromEnv(envName, configName)
  local variable = os.getenv(envName)
  if not variable then
    return
  end
  Api[configName] = variable:gsub("%s+$", "")
end

-- ...

local function loadApiKey(envName, configName, optionName, callback, defaultValue)
  loadConfigFromEnv(envName, configName)
  if not Api[configName] then
    if Config.options[optionName] ~= nil and Config.options[optionName] ~= "" then
      loadConfigFromCommand(Config.options[optionName], optionName, callback, defaultValue)
    else
      logger.warn(envName .. " environment variable not set")
      return
    end
  end
end
```

A simple solution is to pass the callback function in to handle handle if the environment variable is picked up in the config. I'm making a PR for that now.