### PR TITLE
Pass callback function for all Config load from env

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -196,7 +196,9 @@ local function loadConfigFromEnv(envName, configName, callback)
   end
   local value = variable:gsub("%s+$", "")
   Api[configName] = value
-  callback(value)
+  if callback then
+    callback(value)
+  end
 end
 
 local function loadApiHost(envName, configName, optionName, callback, defaultValue)

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -200,7 +200,7 @@ local function loadConfigFromEnv(envName, configName, callback)
 end
 
 local function loadApiHost(envName, configName, optionName, callback, defaultValue)
-  loadConfigFromEnv(envName, configName)
+  loadConfigFromEnv(envName, configName, callback)
   if Api[configName] then
     callback(Api[configName])
   else


### PR DESCRIPTION
PR: https://github.com/jackMort/ChatGPT.nvim/pull/305 fixed the curl error by calling the callback function for all config loads. However, there was one call which doesn't pass a callback (and one where a callback isn't defined) and since it is assumed to be none, the module init fails.

The fix is just to appropriate call the callback when specified
