### PR TITLE
Enables dynamic support for `http` and `https` OPENAI_API_HOSTs 

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -251,12 +251,24 @@ local function loadAzureConfigs()
   end
 end
 
+local function startsWith(str, start)
+  return string.sub(str, 1, string.len(start)) == start
+end
+
+local function ensureUrlProtocol(str)
+  if startsWith(str, "https://") or startsWith(str, "http://") then
+    return str
+  end
+
+  return "https://" .. str
+end
+
 function Api.setup()
   loadApiHost("OPENAI_API_HOST", "OPENAI_API_HOST", "api_host_cmd", function(value)
     Api.OPENAI_API_HOST = value
-    Api.COMPLETIONS_URL = "https://" .. Api.OPENAI_API_HOST .. "/v1/completions"
-    Api.CHAT_COMPLETIONS_URL = "https://" .. Api.OPENAI_API_HOST .. "/v1/chat/completions"
-    Api.EDITS_URL = "https://" .. Api.OPENAI_API_HOST .. "/v1/edits"
+    Api.COMPLETIONS_URL = ensureUrlProtocol(Api.OPENAI_API_HOST .. "/v1/completions")
+    Api.CHAT_COMPLETIONS_URL = ensureUrlProtocol(Api.OPENAI_API_HOST .. "/v1/chat/completions")
+    Api.EDITS_URL = ensureUrlProtocol(Api.OPENAI_API_HOST .. "/v1/edits")
   end, "api.openai.com")
 
   loadApiKey("OPENAI_API_KEY", "OPENAI_API_KEY", "api_key_cmd", function(value)


### PR DESCRIPTION
In order to use local tools that offer an Open AI compatible API (I'm using litellm) without messing around with certificates, I needed to add `http` support to this plugin.

I've done this without breaking any existing behavior. The change detects if the `OPENAI_API_HOST` value starts with either `http://` or `https://`, if it starts with neither, it will automatically add `https://` to the beginning of the URL as before. Otherwise it leaves the URL as is.

I took this approach for two reasons:
1. No breaking change; if this change doesn't concern you, you won't notice it.
2. Security - if the url doesn't have the protocol specified, defaulting to https will ensure there are no accidental unsecured connections.

Thanks for all the work on this project and thanks for your consideration.