### PR TITLE
Remove margin from input window when border style is 'none'.

### DIFF
--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -653,12 +653,10 @@ function Chat:get_layout_params()
       Layout.Box(self.chat_window, { grow = 1 }),
     }, { dir = self.display_mode == "center" and "row" or "col", grow = 1 })
   end
+
   local box = Layout.Box({
     left_layout,
-    Layout.Box(
-      self.chat_input,
-      { size = vim.print(vim.print(self.chat_input.border._.style) == "none" and 0 or 2) + self.prompt_lines }
-    ),
+    Layout.Box(self.chat_input, { size = (self.chat_input.border._.style == "none" and 0 or 2) + self.prompt_lines }),
   }, { dir = "col" })
 
   if self.settings_open then

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -653,17 +653,22 @@ function Chat:get_layout_params()
       Layout.Box(self.chat_window, { grow = 1 }),
     }, { dir = self.display_mode == "center" and "row" or "col", grow = 1 })
   end
-
   local box = Layout.Box({
     left_layout,
-    Layout.Box(self.chat_input, { size = 2 + self.prompt_lines }),
+    Layout.Box(
+      self.chat_input,
+      { size = vim.print(vim.print(self.chat_input.border._.style) == "none" and 0 or 2) + self.prompt_lines }
+    ),
   }, { dir = "col" })
 
   if self.settings_open then
     box = Layout.Box({
       Layout.Box({
         left_layout,
-        Layout.Box(self.chat_input, { size = 2 + self.prompt_lines }),
+        Layout.Box(
+          self.chat_input,
+          { size = (self.chat_input.border._.style == "none" and 0 or 2) + self.prompt_lines }
+        ),
       }, { dir = "col", grow = 1 }),
       Layout.Box({
         Layout.Box(self.settings_panel, { size = "30%" }),


### PR DESCRIPTION
 When the border style is set to "none", the input box unexpectedly gains an additional margin. Here are the screenshots illustrating the issue:
<img width="1792" alt="スクリーンショット 2023-11-18 20 00 01" src="https://github.com/jackMort/ChatGPT.nvim/assets/54583542/88161125-1cc0-4269-b219-3ff484161943">

I fix this issue by setting the input box margin to zero when the border is none.
<img width="1792" alt="スクリーンショット 2023-11-18 20 01 40" src="https://github.com/jackMort/ChatGPT.nvim/assets/54583542/d1200798-7b8d-4f8c-b194-504a97d5ce17">
