### PR TITLE
latest chatgpt-4 preview model for increased token window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChatGPT.nvim
+# ChatGPT.nvim (with gpt-4-1106-preview support)
 
 ![GitHub Workflow Status](http://img.shields.io/github/actions/workflow/status/jackMort/ChatGPT.nvim/default.yml?branch=main&style=for-the-badge)
 ![Lua](https://img.shields.io/badge/Made%20with%20Lua-blueviolet.svg?style=for-the-badge&logo=lua)

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -99,6 +99,7 @@ function Api.make_call(url, params, cb)
     :new({
       command = "curl",
       args = {
+        "--max-time", "10",
         url,
         "-H",
         "Content-Type: application/json",

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -143,7 +143,7 @@ function M.defaults()
       model = "gpt-4-1106-preview",
       frequency_penalty = 0,
       presence_penalty = 0,
-      max_tokens = 10000,
+      max_tokens = 4096,
       temperature = 0,
       top_p = 1,
       n = 1,

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -143,7 +143,7 @@ function M.defaults()
       model = "gpt-4-1106-preview",
       frequency_penalty = 0,
       presence_penalty = 0,
-      max_tokens = 300,
+      max_tokens = 10000,
       temperature = 0,
       top_p = 1,
       n = 1,

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -140,7 +140,7 @@ function M.defaults()
       },
     },
     openai_params = {
-      model = "gpt-3.5-turbo",
+      model = "gpt-4-1106-preview",
       frequency_penalty = 0,
       presence_penalty = 0,
       max_tokens = 300,
@@ -149,7 +149,7 @@ function M.defaults()
       n = 1,
     },
     openai_edit_params = {
-      model = "gpt-3.5-turbo",
+      model = "gpt-4-1106-preview",
       frequency_penalty = 0,
       presence_penalty = 0,
       temperature = 0,


### PR DESCRIPTION
Idk if this goes against your intentions for the plugin since i only recently stumbled on it but i think it would be cool if there was a way for developers to also use the newer chatgpt-4 models since it allows for pretty big prompts and is very fast too.

Ignore this pull request if chatgpt-4 usage is not intended.