### PR TITLE
feat(chat): enable support for gpt 4 vision api

### DIFF
--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -475,6 +475,16 @@ function Chat:toString()
   return str
 end
 
+local function createContent(line)
+  local extensions = { "%.jpeg", "%.jpg", "%.png", "%.gif", "%.bmp", "%.tif", "%.tiff", "%.webp" }
+  for _, ext in ipairs(extensions) do
+    if string.find(line:lower(), ext .. "$") then
+      return { type = "image_url", image_url = line }
+    end
+  end
+  return { type = "text", text = line }
+end
+
 function Chat:toMessages()
   local messages = {}
   if self.system_message ~= nil then
@@ -488,7 +498,15 @@ function Chat:toMessages()
     elseif msg.type == ANSWER then
       role = "assistant"
     end
-    table.insert(messages, { role = role, content = msg.text })
+    local content = {}
+    if self.params.model == "gpt-4-vision-preview" then
+      for _, line in ipairs(msg.lines) do
+        table.insert(content, createContent(line))
+      end
+    else
+      content = msg.text
+    end
+    table.insert(messages, { role = role, content = content })
   end
   return messages
 end


### PR DESCRIPTION
[vision.webm](https://github.com/jackMort/ChatGPT.nvim/assets/61915524/7d568f01-fadf-4775-a516-4daaff48f99e)

Added support for gpt-4-vision-preview.

If you're interested here's the plugin I wrote to get the image from the clipboard to cloudinary ;)
https://github.com/e2r2fx/cloudy.nvim

Another possible feature is to add image previews with [image.nvim](https://github.com/3rd/image.nvim) to the chat window