### PR TITLE
Allow loading custom prompts from local file

### DIFF
--- a/lua/chatgpt/prompts.lua
+++ b/lua/chatgpt/prompts.lua
@@ -84,10 +84,15 @@ local finder = function(opts)
       if not job_started then
 
         local load_file_command = ""
-        if string.match(opts.url, "^/") ~= nil then
+        local expanded_url = vim.fn.expand(opts.url)
+        local file_or_web_url = ""
+        local starts_with_slash = string.match(expanded_url, "^/") ~= nil
+        if starts_with_slash then
           load_file_command = "cat"
+          file_or_web_url = expanded_url
         else
           load_file_command = "curl"
+          file_or_web_url = opts.url
         end
 
         job_started = true
@@ -96,7 +101,7 @@ local finder = function(opts)
           :new({
             command = load_file_command,
             args = {
-              opts.url,
+              file_or_web_url,
             },
             on_exit = vim.schedule_wrap(function(j, exit_code)
               if exit_code ~= 0 then

--- a/lua/chatgpt/prompts.lua
+++ b/lua/chatgpt/prompts.lua
@@ -82,10 +82,19 @@ local finder = function(opts)
       end
 
       if not job_started then
+
+        local load_file_command = ""
+        if string.match(opts.url, "^/") ~= nil then
+          load_file_command = "cat"
+        else
+          load_file_command = "curl"
+        end
+
         job_started = true
+
         job
           :new({
-            command = "curl",
+            command = load_file_command,
             args = {
               opts.url,
             },


### PR DESCRIPTION
## Summary

`predefined_chat_gpt_prompts` can now load a CSV file from a local path as well as a web URL. The loader expands paths such as `~` and `$HOME`, uses `cat` for an absolute local path, and keeps `curl` for web URLs.

## Related context

- Follow-up use case: https://github.com/jackMort/ChatGPT.nvim/issues/52#issuecomment-1857966411
