### PR TITLE
List in README "folke/trouble.nvim" as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ use({
     requires = {
       "MunifTanjim/nui.nvim",
       "nvim-lua/plenary.nvim",
+      "folke/trouble.nvim",
       "nvim-telescope/telescope.nvim"
     }
 })
@@ -63,6 +64,7 @@ use({
     dependencies = {
       "MunifTanjim/nui.nvim",
       "nvim-lua/plenary.nvim",
+      "folke/trouble.nvim",
       "nvim-telescope/telescope.nvim"
     }
 }


### PR DESCRIPTION
To correctly execute the command:

```
ChatGPTRun code_readability_analysis
```

It is necessary to have the "trouble.nvim" plugin.

Otherwise you get the nvim error saying:

```
Vim:E492: Not an editor command: Trouble quickfix
```

This commit makes it explicit in the README that trouble plugin is a dependency.

The `trouble` dependency is here: 
 https://github.com/jackMort/ChatGPT.nvim/blob/48c59167beeb6ee0caa501c46cecc97b9be8571d/lua/chatgpt/config.lua#L176
![image](https://github.com/jackMort/ChatGPT.nvim/assets/150758/6014c3a4-0874-4580-8f37-a02b8a945db2)
