### PR TITLE
Handle invalid action

### DIFF
--- a/lua/chatgpt/flows/actions/init.lua
+++ b/lua/chatgpt/flows/actions/init.lua
@@ -54,6 +54,25 @@ function M.run_action(opts)
   local action_name = opts.fargs[1]
   local item = ACTIONS[action_name]
 
+  if item == nil then
+    if action_name == nil then
+      vim.notify("You need to specify an action", vim.log.levels.WARN)
+    else
+      vim.notify('Invalid input: "' .. action_name .. '"\n', vim.log.levels.WARN)
+    end
+
+    -- show the available valid actions
+    local keys = {}
+    for k, _ in pairs(ACTIONS) do
+      table.insert(keys, k)
+    end
+    local s = table.concat(keys, ", ")
+
+    vim.notify("Valid actions are: " .. s, vim.log.levels.WARN)
+
+    return
+  end
+
   -- parse args
   --
   if item.args then


### PR DESCRIPTION
Whenever the user inputs a invalid action, indicate the action does not exist, and show a list of the available actions.

Before:

![image](https://github.com/jackMort/ChatGPT.nvim/assets/150758/82affcac-3124-4353-9a11-a01b13f7ee66)

After:

![image](https://github.com/jackMort/ChatGPT.nvim/assets/150758/566cdf98-e1d7-44c9-92b5-79ac796c428b)