### PR TITLE
Add the ability to use additional parameters in requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Custom OpenAI API host with the configuration option `api_host_cmd` or
 environment variable called `$OPENAI_API_HOST`. It's useful if you can't access
 OpenAI directly
 
+Custom cURL parameters can be passed using the configuration option `extra_curl_params`.
+It can be useful if you need to include additional headers for requests:
+```lua
+{
+  ...,
+  extra_curl_params = {
+    "-H",
+    "Origin: https://example.com"
+  }
+}
+```
+
 For Azure deployments, you also need to set environment variables
 `$OPENAI_API_TYPE` to `azure`, `$OPENAI_API_BASE` to your own resource URL,
 e.g. `https://{your-resource-name}.openai.azure.com`, and `$OPENAI_API_AZURE_ENGINE`

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -10,6 +10,7 @@ function M.defaults()
   local defaults = {
     api_key_cmd = nil,
     yank_register = "+",
+    extra_curl_params = nil,
     edit_with_instructions = {
       diff = false,
       keymaps = {


### PR DESCRIPTION
Good day!
Since the official API is not accessible in my country, I must rely on third-party alternatives.
Some of them require the inclusion of specific request headers, such as 'Origin' and 'Referrer.'
The modifications in this pull request enable the specification of these headers without causing any breaking changes.

I have also added a description of usage in the README.
