### PR TITLE
fix: Failed to launch in neovim 0.9.5 #371

### DIFF
--- a/lua/chatgpt/help.lua
+++ b/lua/chatgpt/help.lua
@@ -40,7 +40,7 @@ M.get_help_panel = function(type)
 
   for _, k in pairs(settings_keys) do
     local key = NuiText(
-      " " .. settings[k] .. string.rep(" ", max_setting_value_length + 1 - #settings[k]),
+      " " .. tostring(settings[k]) .. string.rep(" ", max_setting_value_length + 1 - #settings[k]),
       Config.options.highlights.help_key
     )
 


### PR DESCRIPTION
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1702233742
```

```
Error executing Lua callback: ....local/share/nvim/lazy/ChatGPT.nvim/lua/chatgpt/help.lua:43: attempt to concatenate a table value                                                                                                                                                                                                                                          
stack traceback:                                                                                                                                                                                                                                                                                                                                                            
        ....local/share/nvim/lazy/ChatGPT.nvim/lua/chatgpt/help.lua:43: in function 'get_help_panel'                                                                                                                                                                                                                                                                        
        ...e/nvim/lazy/ChatGPT.nvim/lua/chatgpt/flows/chat/base.lua:727: in function 'open'                                                                                                                                                                                                                                                                                 
        ...e/nvim/lazy/ChatGPT.nvim/lua/chatgpt/flows/chat/init.lua:14: in function 'open_chat'                                                                                                                                                                                                                                                                             
        ...nluc/.local/share/nvim/lazy/ChatGPT.nvim/lua/chatgpt.lua:34: in function 'openChat'     
```                                                                                                               