### PR TITLE
fix: update draft keybind to match #f1453f5

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ keybindings are available:
 - `<C-d>` [Chat] scroll down chat window.
 - `<C-k>` [Chat] to copy/yank code from last answer.
 - `<C-n>` [Chat] Start new session.
-- `<C-d>` [Chat] draft message (create message without submitting it to server)
+- `<C-r>` [Chat] draft message (create message without submitting it to server)
 - `<C-r>` [Chat] switch role (switch between user and assistant role to define a workflow)
 - `<C-s>` [Both] Toggle system message window.
 - `<C-i>` [Edit Window] use response as input.


### PR DESCRIPTION
Addresses

https://github.com/jackMort/ChatGPT.nvim/commit/f1453f588eb47e49e57fa34ac1776b795d71e2f1
https://github.com/jackMort/ChatGPT.nvim/issues/263

Though I noticed that section of the README still contains duplicate keybinds. Unsure whether that is actionable.