### PR TITLE
Fixes configuration loss.

### DIFF
--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -190,7 +190,11 @@ M.namespace_id = vim.api.nvim_create_namespace("ChatGPTNS")
 
 function M.setup(options)
   options = options or {}
-  M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
+  if next(M.options) == nil then
+    M.options = vim.tbl_deep_extend("force", {}, M.defaults(), options)
+  else
+    M.options = vim.tbl_deep_extend("force", {}, M.options, options)
+  end
 end
 
 return M


### PR DESCRIPTION
For some reason, Neovim calls the setup function twice during startup, resulting in the loss of individual settings.