### PR TITLE
feat: add option to set nonumber for popup windows

### DIFF
--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -127,7 +127,9 @@ local setup_and_mount = vim.schedule_wrap(function(lines, output_lines, ...)
   -- set input and output settings
   for _, window in ipairs({ input_window, output_window }) do
     vim.api.nvim_buf_set_option(window.bufnr, "filetype", filetype)
-    vim.api.nvim_win_set_option(window.winid, "number", true)
+    if Config.options.show_line_numbers ~= false then
+      vim.api.nvim_win_set_option(window.winid, "number", true)
+    end
   end
 end)
 

--- a/lua/chatgpt/config.lua
+++ b/lua/chatgpt/config.lua
@@ -11,6 +11,7 @@ function M.defaults()
     api_key_cmd = nil,
     yank_register = "+",
     extra_curl_params = nil,
+    show_line_numbers = true,
     edit_with_instructions = {
       diff = false,
       keymaps = {


### PR DESCRIPTION
Addresses #234 

- add 'show_line_numbers = true' to default config
- add check in code_edits.lua before setting the line numbers for the window
- setting 'show_line_numbers = false' will disable the line numbers


when setting show_line_numbers = false, it would be advisable to also set the popup_window.win_options.foldcolumn = "0", to get clean experience, but I left that option for the users.