### PR TITLE
Fix issue with cycling panes in edit_with_instructions

### DIFF
--- a/lua/chatgpt/code_edits.lua
+++ b/lua/chatgpt/code_edits.lua
@@ -352,6 +352,7 @@ M.edit_with_instructions = function(output_lines, bufnr, selection, ...)
         goto continue
       end
       popup:map(mode, Config.options.edit_with_instructions.keymaps.cycle_windows, function()
+        active_panel = active_panel or instructions_input -- otherwise active_panel is nil when window opens
         local in_table = inTable(open_extra_panels, active_panel)
         if active_panel == instructions_input then
           vim.api.nvim_set_current_win(input_window.winid)


### PR DESCRIPTION
This Fixes https://github.com/jackMort/ChatGPT.nvim/issues/352

Closes #352

Something in 1f69ba2 broke this - here's a fix for it.

For some reason the active_panel is coming up nil when the view initially opens. It's being set at the top, but something is overwriting it.