### PR TITLE
[bug fix] Fix the code error when there is a null value in the json returned by the api

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -54,7 +54,12 @@ function Api.chat_completions(custom_params, cb, should_stop)
           if raw_json == "[DONE]" then
             cb(raw_chunks, "END")
           else
-            ok, json = pcall(vim.json.decode, raw_json)
+            ok, json = pcall(vim.json.decode, raw_json, {
+              luanil = {
+                object = true,
+                array = true,
+              },
+            })
             if ok and json ~= nil then
               if
                 json


### PR DESCRIPTION
add param to [vim.json.decode](https://neovim.io/doc/user/lua.html#vim.json) , converts null in JSON objects to Lua nil instead of [vim.NIL](https://neovim.io/doc/user/lua.html#vim.NIL)

Because:
```lua
if vim.NIL then
  -- The following code will execute
  print("hello");
end
```
