### PR TITLE
docs: add missing code block separator in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ use({
       "nvim-telescope/telescope.nvim"
     }
 })
+```
 
 or if you are using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
+```lua
 -- Lazy
 {
   "jackMort/ChatGPT.nvim",


### PR DESCRIPTION
Thanks to maintaining great neovim plugin!

I added missing code block separator in `README.md`.