### PR TITLE
Escape % to avoid "invalid capture index problem" when % in the input

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ keybindings are available:
 - `<C-f>` [Chat] Cycle over modes (center, stick to right).
 - `<C-c>` [Both] to close chat window.
 - `<C-p>` [Chat] Toggle sessions list.
+- `<cr>` &nbsp;[Chat] Select a session.
 - `<C-u>` [Chat] scroll up chat window.
 - `<C-d>` [Chat] scroll down chat window.
 - `<C-k>` [Chat] to copy/yank code from last answer.

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -146,32 +146,37 @@ Api.handle_response = vim.schedule_wrap(function(response, exit_code, cb)
   end
 
   local result = table.concat(response:result(), "\n")
-  local json = vim.fn.json_decode(result)
-  if json == nil then
+
+  if result == "" then
     cb("No Response.")
-  elseif json.error then
-    cb("// API ERROR: " .. json.error.message)
   else
-    local message = json.choices[1].message
-    if message ~= nil then
-      local message_response
-      local first_message = json.choices[1].message
-      if first_message.function_call then
-        message_response = vim.fn.json_decode(first_message.function_call.arguments)
-      else
-        message_response = first_message.content
-      end
-      if (type(message_response) == "string" and message_response ~= "") or type(message_response) == "table" then
-        cb(message_response, json.usage)
-      else
-        cb("...")
-      end
+    local json = vim.fn.json_decode(result)
+    if json == nil then
+      cb("No Response.")
+    elseif json.error then
+      cb("// API ERROR: " .. json.error.message)
     else
-      local response_text = json.choices[1].text
-      if type(response_text) == "string" and response_text ~= "" then
-        cb(response_text, json.usage)
+      local message = json.choices[1].message
+      if message ~= nil then
+        local message_response
+        local first_message = json.choices[1].message
+        if first_message.function_call then
+          message_response = vim.fn.json_decode(first_message.function_call.arguments)
+        else
+          message_response = first_message.content
+        end
+        if (type(message_response) == "string" and message_response ~= "") or type(message_response) == "table" then
+          cb(message_response, json.usage)
+        else
+          cb("...")
+        end
       else
-        cb("...")
+        local response_text = json.choices[1].text
+        if type(response_text) == "string" and response_text ~= "" then
+          cb(response_text, json.usage)
+        else
+          cb("...")
+        end
       end
     end
   end

--- a/lua/chatgpt/flows/actions/chat/init.lua
+++ b/lua/chatgpt/flows/actions/chat/init.lua
@@ -49,6 +49,7 @@ function ChatAction:render_template()
   data = vim.tbl_extend("force", {}, data, self.variables)
   local result = self.template
   for key, value in pairs(data) do
+    value = value:gsub("%%", "%%%%")
     result = result:gsub("{{" .. key .. "}}", value)
   end
   return result


### PR DESCRIPTION
Hey,
If you select a line with a "%" for example
" while (fscanf(src, "%30s ", str) == 1) "
And try to  run a ChatGPTRun command such as code_readbility_analysis you will have an error `invalid capture index` lua/chatgpt/flows/actions/chat/init.lua:52
The reason it happens is that when there is a % it is interpreted as a capture index by gsub but of course it is not intended. We need to escape those.
The resulting code is `value = value:gsub("%%", "%%%%")` because inside a string the % themselve need to be escaped too.
It it tested and fix the problem on my side.