### PR TITLE
Escape % to avoid "invalid capture index problem" when % in the input

### DIFF
--- a/lua/chatgpt/flows/actions/chat/init.lua
+++ b/lua/chatgpt/flows/actions/chat/init.lua
@@ -49,6 +49,7 @@ function ChatAction:render_template()
   data = vim.tbl_extend("force", {}, data, self.variables)
   local result = self.template
   for key, value in pairs(data) do
+    value = value:gsub("%%", "%%%%")
     result = result:gsub("{{" .. key .. "}}", value)
   end
   return result


### PR DESCRIPTION
Hey,
If you select a line with a "%" for example
" while (fscanf(src, "%30s ", str) == 1) "
And try to run a ChatGPTRun command such as code_readbility_analysis you will have an error invalid capture index lua/chatgpt/flows/actions/chat/init.lua:52
The reason it happens is that when there is a % it is interpreted as a capture index by gsub but of course it is not intended. We need to escape those.
The resulting code is value = value:gsub("%%", "%%%%") because inside a string the % themselve need to be escaped too.
It it tested and fix the problem on my side.

PS : I had to close previous PR because I made commit from other PRs mistakenly