### PR TITLE
Change model on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,43 @@ or if you are using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ## Configuration
 
-`ChatGPT.nvim` comes with the following defaults, you can override them by
-passing config as setup param
+`ChatGPT.nvim` comes with the following defaults, you can override them by passing config as setup param
 
 https://github.com/jackMort/ChatGPT.nvim/blob/f1453f588eb47e49e57fa34ac1776b795d71e2f1/lua/chatgpt/config.lua#L10-L182
+
+### Example Configuration
+
+A simple configuration of the chat model could look something like this:
+```lua
+{
+  "jackMort/ChatGPT.nvim",
+  event = "VeryLazy",
+  config = function()
+    require("chatgpt").setup({
+      -- this config assumes you have OPENAI_API_KEY environment variable set
+      openai_params = {
+        -- NOTE: model can be a function returning the model name
+        -- this is useful if you want to change the model on the fly
+        -- using commands
+        -- Example:
+        -- model = function() if some_condition() then return "gpt-4-1106-preview" else return "gpt-3.5-turbo" end end
+        model = "gpt-4-1106-preview",
+        frequency_penalty = 0,
+        presence_penalty = 0,
+        max_tokens = 4095,
+        temperature = 0.2,
+        top_p = 0.1,
+        n = 1,
+      }
+    })
+  end,
+  dependencies = {
+    "MunifTanjim/nui.nvim",
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope.nvim"
+  }
+}
+```
 
 ### Secrets Management
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ A simple configuration of the chat model could look something like this:
         -- this is useful if you want to change the model on the fly
         -- using commands
         -- Example:
-        -- model = function() if some_condition() then return "gpt-4-1106-preview" else return "gpt-3.5-turbo" end end
+        -- model = function()
+        --     if some_condition() then
+        --         return "gpt-4-1106-preview"
+        --     else
+        --         return "gpt-3.5-turbo"
+        --     end
+        -- end,
         model = "gpt-4-1106-preview",
         frequency_penalty = 0,
         presence_penalty = 0,

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -19,6 +19,7 @@ function Api.chat_completions(custom_params, cb, should_stop)
   if params.model == "<dynamic>" then
     params.model = openai_params.model
   end
+  vim.notify("Sending request with model " .. params.model)
   local stream = params.stream or false
   if stream then
     local raw_chunks = ""

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -14,6 +14,11 @@ end
 function Api.chat_completions(custom_params, cb, should_stop)
   local openai_params = Utils.collapsed_openai_params(Config.options.openai_params)
   local params = vim.tbl_extend("keep", custom_params, openai_params)
+  -- the custom params contains <dynamic> if model is not constant but function
+  -- therefore, use collapsed openai params (with function evaluated to get model) if that is the case
+  if params.model == "<dynamic>" then
+    params.model = openai_params.model
+  end
   local stream = params.stream or false
   if stream then
     local raw_chunks = ""

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -19,7 +19,7 @@ function Api.chat_completions(custom_params, cb, should_stop)
   if params.model == "<dynamic>" then
     params.model = openai_params.model
   end
-  vim.notify("Sending request with model " .. params.model)
+  vim.notify("Sending request with model " .. params.model .. " (openai model is " .. openai_params.model .. ")")
   local stream = params.stream or false
   if stream then
     local raw_chunks = ""

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -1,41 +1,18 @@
 local job = require("plenary.job")
 local Config = require("chatgpt.config")
 local logger = require("chatgpt.common.logger")
+local Utils = require("chatgpt.utils")
 
 local Api = {}
 
----@param tbl table
----@return table
-local function table_shallow_copy(tbl)
-  local copy = {}
-  for key, value in pairs(tbl) do
-    copy[key] = value
-  end
-  return copy
-end
-
---- A function that collapses the openai params.
---- This means all the parameters of the openai_params that can be either constants or functions
---- will be set to constants by evaluating the functions.
----@param openai_params table
----@return table
-local function collapsed_openai_params(openai_params)
-  local collapsed = table_shallow_copy(openai_params)
-  -- use copied version of table so the original model value remains a function and can still change
-  if type(collapsed.model) == "function" then
-    collapsed.model = collapsed.model()
-  end
-  return collapsed
-end
-
 function Api.completions(custom_params, cb)
-  local openai_params = collapsed_openai_params(Config.options.openai_params)
+  local openai_params = Utils.collapsed_openai_params(Config.options.openai_params)
   local params = vim.tbl_extend("keep", custom_params, openai_params)
   Api.make_call(Api.COMPLETIONS_URL, params, cb)
 end
 
 function Api.chat_completions(custom_params, cb, should_stop)
-  local openai_params = collapsed_openai_params(Config.options.openai_params)
+  local openai_params = Utils.collapsed_openai_params(Config.options.openai_params)
   local params = vim.tbl_extend("keep", custom_params, openai_params)
   local stream = params.stream or false
   if stream then
@@ -116,7 +93,7 @@ function Api.chat_completions(custom_params, cb, should_stop)
 end
 
 function Api.edits(custom_params, cb)
-  local openai_params = collapsed_openai_params(Config.options.openai_params)
+  local openai_params = Utils.collapsed_openai_params(Config.options.openai_params)
   local params = vim.tbl_extend("keep", custom_params, openai_params)
   if params.model == "text-davinci-edit-001" or params.model == "code-davinci-edit-001" then
     vim.notify("Edit models are deprecated", vim.log.levels.WARN)

--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -19,7 +19,6 @@ function Api.chat_completions(custom_params, cb, should_stop)
   if params.model == "<dynamic>" then
     params.model = openai_params.model
   end
-  vim.notify("Sending request with model " .. params.model .. " (openai model is " .. openai_params.model .. ")")
   local stream = params.stream or false
   if stream then
     local raw_chunks = ""

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -744,7 +744,7 @@ function Chat:open()
   -- TODO: if the current model should be displayed, the settings_panel would
   -- have to be constantly modified or rewritten to be able to manage a function
   -- returning the model as well
-  for value, key in pairs(displayed_params) do
+  for value, key in pairs(self.params) do
     if type(value) == "function" then
       displayed_params[key] = "<dynamic>"
     end

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -737,6 +737,7 @@ end
 
 function Chat:open()
   local openai_params = Utils.collapsed_openai_params(self.params)
+  vim.notify(vim.inspect(self.params))
   vim.notify(vim.inspect(openai_params))
   self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
   self.help_panel = Help.get_help_panel("chat")

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -745,7 +745,7 @@ function Chat:open()
   -- have to be constantly modified or rewritten to be able to manage a function
   -- returning the model as well
   vim.notify("Chat.params are " .. vim.inspect(displayed_params) .. " and should equal " .. vim.inspect(self.params))
-  for value, key in pairs(self.params) do
+  for key, value in pairs(self.params) do
     if type(value) == "function" then
       displayed_params[key] = "<dynamic>"
     end

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -736,10 +736,20 @@ function Chat:get_layout_params()
 end
 
 function Chat:open()
-  local openai_params = Utils.collapsed_openai_params(self.params)
-  vim.notify(vim.inspect(self.params))
-  vim.notify(vim.inspect(openai_params))
-  self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
+  -- local openai_params = Utils.collapsed_openai_params(self.params)
+  -- vim.notify(vim.inspect(self.params))
+  -- vim.notify(vim.inspect(openai_params))
+  local displayed_params = Utils.table_shallow_copy(self.params)
+  -- if the param is decided by a function and not constant, write <dynamic> for now
+  -- TODO: if the current model should be displayed, the settings_panel would
+  -- have to be constantly modified or rewritten to be able to manage a function
+  -- returning the model as well
+  for value, key in pairs(displayed_params) do
+    if type(value) == "function" then
+      displayed_params[key] = "<dynamic>"
+    end
+  end
+  self.settings_panel = Settings.get_settings_panel("chat_completions", displayed_params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)
     self:set_session(session)
@@ -1029,8 +1039,6 @@ function Chat:open_system_panel()
 end
 
 function Chat:redraw(noinit)
-  local openai_params = Utils.collapsed_openai_params(self.params)
-  self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
   noinit = noinit or false
   self.layout:update(self:get_layout_params())
   if not noinit then

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -517,7 +517,7 @@ function Chat:toMessages()
       role = "assistant"
     end
     local content = {}
-    if Utils.collapsed_openai_params(self.params.model) == "gpt-4-vision-preview" then
+    if Utils.collapsed_openai_params(self.params).model == "gpt-4-vision-preview" then
       for _, line in ipairs(msg.lines) do
         table.insert(content, createContent(line))
       end

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -736,21 +736,16 @@ function Chat:get_layout_params()
 end
 
 function Chat:open()
-  -- local openai_params = Utils.collapsed_openai_params(self.params)
-  -- vim.notify(vim.inspect(self.params))
-  -- vim.notify(vim.inspect(openai_params))
   local displayed_params = Utils.table_shallow_copy(self.params)
   -- if the param is decided by a function and not constant, write <dynamic> for now
   -- TODO: if the current model should be displayed, the settings_panel would
   -- have to be constantly modified or rewritten to be able to manage a function
   -- returning the model as well
-  vim.notify("Chat.params are " .. vim.inspect(displayed_params) .. " and should equal " .. vim.inspect(self.params))
   for key, value in pairs(self.params) do
     if type(value) == "function" then
       displayed_params[key] = "<dynamic>"
     end
   end
-  vim.notify("processed displayed_params are " .. vim.inspect(displayed_params))
   self.settings_panel = Settings.get_settings_panel("chat_completions", displayed_params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -517,7 +517,7 @@ function Chat:toMessages()
       role = "assistant"
     end
     local content = {}
-    if self.params.model == "gpt-4-vision-preview" then
+    if Utils.collapsed_openai_params(self.params.model) == "gpt-4-vision-preview" then
       for _, line in ipairs(msg.lines) do
         table.insert(content, createContent(line))
       end
@@ -1029,6 +1029,8 @@ function Chat:open_system_panel()
 end
 
 function Chat:redraw(noinit)
+  local openai_params = Utils.collapsed_openai_params(self.params)
+  self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
   noinit = noinit or false
   self.layout:update(self:get_layout_params())
   if not noinit then

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -737,6 +737,7 @@ end
 
 function Chat:open()
   local openai_params = Utils.collapsed_openai_params(self.params)
+  vim.notify(vim.inspect(openai_params))
   self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -736,7 +736,8 @@ function Chat:get_layout_params()
 end
 
 function Chat:open()
-  self.settings_panel = Settings.get_settings_panel("chat_completions", self.params)
+  local openai_params = Utils.collapsed_openai_params(self.params)
+  self.settings_panel = Settings.get_settings_panel("chat_completions", openai_params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)
     self:set_session(session)

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -744,11 +744,13 @@ function Chat:open()
   -- TODO: if the current model should be displayed, the settings_panel would
   -- have to be constantly modified or rewritten to be able to manage a function
   -- returning the model as well
+  vim.notify("Chat.params are " .. vim.inspect(displayed_params) .. " and should equal " .. vim.inspect(self.params))
   for value, key in pairs(self.params) do
     if type(value) == "function" then
       displayed_params[key] = "<dynamic>"
     end
   end
+  vim.notify("processed displayed_params are " .. vim.inspect(displayed_params))
   self.settings_panel = Settings.get_settings_panel("chat_completions", displayed_params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -69,6 +69,7 @@ end
 M.get_settings_panel = function(type, default_params)
   M.type = type
   local custom_params = M.read_config()
+  vim.notify("reading of custom params returned " .. vim.inspect(custom_params))
   M.params = vim.tbl_deep_extend("force", {}, default_params, custom_params or {})
 
   M.panel = Popup(Config.options.settings_window)

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -70,7 +70,6 @@ M.get_settings_panel = function(type, default_params)
   M.type = type
   local custom_params = M.read_config()
   M.params = vim.tbl_deep_extend("force", {}, default_params, custom_params or {})
-  vim.notify("Settings.params are " .. vim.inspect(M.params))
 
   M.panel = Popup(Config.options.settings_window)
 

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -69,8 +69,8 @@ end
 M.get_settings_panel = function(type, default_params)
   M.type = type
   local custom_params = M.read_config()
-  -- vim.notify("reading of custom params returned " .. vim.inspect(custom_params))
   M.params = vim.tbl_deep_extend("force", {}, default_params, custom_params or {})
+  vim.notify("Settings.params are " .. vim.inspect(M.params))
 
   M.panel = Popup(Config.options.settings_window)
 

--- a/lua/chatgpt/settings.lua
+++ b/lua/chatgpt/settings.lua
@@ -69,7 +69,7 @@ end
 M.get_settings_panel = function(type, default_params)
   M.type = type
   local custom_params = M.read_config()
-  vim.notify("reading of custom params returned " .. vim.inspect(custom_params))
+  -- vim.notify("reading of custom params returned " .. vim.inspect(custom_params))
   M.params = vim.tbl_deep_extend("force", {}, default_params, custom_params or {})
 
   M.panel = Popup(Config.options.settings_window)

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -2,6 +2,30 @@ local M = {}
 
 local ESC_FEEDKEY = vim.api.nvim_replace_termcodes("<ESC>", true, false, true)
 
+---@param tbl table
+---@return table
+function M.table_shallow_copy(tbl)
+  local copy = {}
+  for key, value in pairs(tbl) do
+    copy[key] = value
+  end
+  return copy
+end
+
+--- A function that collapses the openai params.
+--- This means all the parameters of the openai_params that can be either constants or functions
+--- will be set to constants by evaluating the functions.
+---@param openai_params table
+---@return table
+function M.collapsed_openai_params(openai_params)
+  local collapsed = M.table_shallow_copy(openai_params)
+  -- use copied version of table so the original model value remains a function and can still change
+  if type(collapsed.model) == "function" then
+    collapsed.model = collapsed.model()
+  end
+  return collapsed
+end
+
 function M.split(text)
   local t = {}
   for str in string.gmatch(text, "%S+") do

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -20,9 +20,12 @@ end
 function M.collapsed_openai_params(openai_params)
   local collapsed = M.table_shallow_copy(openai_params)
   -- use copied version of table so the original model value remains a function and can still change
+  vim.notify("collapsing openai params: params " .. openai_params)
   if type(collapsed.model) == "function" then
     collapsed.model = collapsed.model()
   end
+  vim.notify("collapsing openai params: collapsed" .. collapsed)
+  vim.notify("collapsing openai params: params now" .. openai_params)
   return collapsed
 end
 

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -20,12 +20,12 @@ end
 function M.collapsed_openai_params(openai_params)
   local collapsed = M.table_shallow_copy(openai_params)
   -- use copied version of table so the original model value remains a function and can still change
-  vim.notify("collapsing openai params: params " .. openai_params)
+  vim.notify("collapsing openai params: params " .. vim.inspect(openai_params))
   if type(collapsed.model) == "function" then
     collapsed.model = collapsed.model()
   end
-  vim.notify("collapsing openai params: collapsed" .. collapsed)
-  vim.notify("collapsing openai params: params now" .. openai_params)
+  vim.notify("collapsing openai params: collapsed" .. vim.inspect(collapsed))
+  vim.notify("collapsing openai params: params now" .. vim.inspect(openai_params))
   return collapsed
 end
 

--- a/lua/chatgpt/utils.lua
+++ b/lua/chatgpt/utils.lua
@@ -20,12 +20,9 @@ end
 function M.collapsed_openai_params(openai_params)
   local collapsed = M.table_shallow_copy(openai_params)
   -- use copied version of table so the original model value remains a function and can still change
-  vim.notify("collapsing openai params: params " .. vim.inspect(openai_params))
   if type(collapsed.model) == "function" then
     collapsed.model = collapsed.model()
   end
-  vim.notify("collapsing openai params: collapsed" .. vim.inspect(collapsed))
-  vim.notify("collapsing openai params: params now" .. vim.inspect(openai_params))
   return collapsed
 end
 


### PR DESCRIPTION
Earlier this day, I raised an issue here: https://github.com/jackMort/ChatGPT.nvim/issues/414
Then, I decided to dive into the codebase and add the feature myself using my proposed change.

# What's new:
openai_params.model can now be either a constant string (only method so far) or **a function that returns a string containing the model** (new). The model is thus computed on the fly when an API request is made.

# Motivation for the change
So far, without this change, it has not been possible to change the model you are using on the fly. With the modifications this PR introduces, one can now pass a function instead of a fixed model, and the function returns the model to be used. This function is evaluated on API invokation.

# Code changes:
- add a Utils.collapse_openai_params function to, if the openai_params.model parameter is a function, evaluate the function when an API request is made
- add Utils.table_shallow_copy as a helper function for Utils.collapse_openai_params
- if the model is determined on the fly, write \<dynamic\> in the settings menu
- added documentation and a condiguration example to the README.md

# Testing
I have tested every related command (ChatGPT, ChatGPTActAs, ChatGPTRun) and they're all still working perfectly.

# Apology letter (lol)
Finally, I want to apologize for the many "debugging" commits. While working on the feature, I found it easiest to commit the changes and let lazy put them into my editor so I could test them, then go back to the plugin.