### PR TITLE
Add `filepath` to action variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ An example of custom action may look like this: (`#` marks comments)
   "action_name": {
     "type": "chat", # or "completion" or "edit"
     "opts": {
-      "template": "A template using possible variable: {{filetype}} (neovim filetype), {{input}} (the selected text) an {{argument}} (provided on the command line), {{filepath}} (the full path to the file)",
+      "template": "A template using possible variable: {{filetype}} (neovim filetype), {{input}} (the selected text) an {{argument}} (provided on the command line), {{filepath}} (the relative path to the file)",
       "strategy": "replace", # or "display" or "append" or "edit"
       "params": { # parameters according to the official OpenAI API
         "model": "gpt-3.5-turbo", # or any other model supported by `"type"` in the OpenAI API, use the playground for reference

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ An example of custom action may look like this: (`#` marks comments)
   "action_name": {
     "type": "chat", # or "completion" or "edit"
     "opts": {
-      "template": "A template using possible variable: {{filetype}} (neovim filetype), {{input}} (the selected text) an {{argument}} (provided on the command line)",
+      "template": "A template using possible variable: {{filetype}} (neovim filetype), {{input}} (the selected text) an {{argument}} (provided on the command line), {{filepath}} (the full path to the file)",
       "strategy": "replace", # or "display" or "append" or "edit"
       "params": { # parameters according to the official OpenAI API
         "model": "gpt-3.5-turbo", # or any other model supported by `"type"` in the OpenAI API, use the playground for reference

--- a/lua/chatgpt/flows/actions/base.lua
+++ b/lua/chatgpt/flows/actions/base.lua
@@ -34,7 +34,16 @@ end
 
 function BaseAction:get_filepath()
   local bufnr = self:get_bufnr()
-  return vim.api.nvim_buf_get_name(bufnr)
+  local full_path = vim.api.nvim_buf_get_name(bufnr)
+  -- Get relative path
+  local cwd = vim.fn.getcwd()
+  local rel_path = vim.fn.fnamemodify(full_path, ":~:.")
+
+  if string.find(rel_path, cwd, 1, true) == 1 then
+    return string.sub(rel_path, #cwd + 2)
+  end
+
+  return rel_path
 end
 
 function BaseAction:get_visual_selection()

--- a/lua/chatgpt/flows/actions/base.lua
+++ b/lua/chatgpt/flows/actions/base.lua
@@ -32,6 +32,11 @@ function BaseAction:get_filetype()
   return vim.api.nvim_buf_get_option(bufnr, "filetype")
 end
 
+function BaseAction:get_filepath()
+  local bufnr = self:get_bufnr()
+  return vim.api.nvim_buf_get_name(bufnr)
+end
+
 function BaseAction:get_visual_selection()
   -- return lines and selection, but caches them, so they always are the ones used
   -- when the action was started, even if the user has changed buffer/selection

--- a/lua/chatgpt/flows/actions/chat/init.lua
+++ b/lua/chatgpt/flows/actions/chat/init.lua
@@ -44,6 +44,7 @@ function ChatAction:render_template()
     or self:get_selected_text()
   local data = {
     filetype = self:get_filetype(),
+    filepath = self:get_filepath(),
     input = input,
   }
   data = vim.tbl_extend("force", {}, data, self.variables)


### PR DESCRIPTION
Currently, action templates support the following variables: {{filetype}} (neovim filetype), {{input}} (the selected text) and an {{argument}} (provided on the command line). 

During an exploration in writing tests with LLMs, I found that providing the path to the file relative to the root of my project allowed my LLM to properly import the file to write the tests for it.

So I contributed `{{filepath}}`, a new variable which gets the relative path to the file being operated on.

This was done by adding a new method `get_filepath` to `BaseAction` and adding the `filepath` variable to `render_template`. 

I tested this by writing a template with `{{filepath}}` and observing the path getting put into the prompt with this OpenAI compatible API https://gist.github.com/Berkodev/77000c57ec49f41ce73b754d684f10f9#file-openai_compatible_api_example-py