### PR TITLE
feat: visual selection appended in chat 

### DIFF
--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -30,8 +30,6 @@ function Chat:init()
   -- quit indicator
   self.active = true
 
-  self.editor_bufnr = nil
-
   -- UI ELEMENTS
   self.layout = nil
   self.chat_panel = nil
@@ -739,7 +737,6 @@ end
 
 function Chat:open()
   local editor_bufnr = vim.api.nvim_get_current_buf()
-  self.editor_bufnr = editor_bufnr
   local visual_lines = {}
   -- if in visual, visual line, visual block modes
   if vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == "\22" then
@@ -1050,7 +1047,6 @@ end
 
 function Chat:show()
   local editor_bufnr = vim.api.nvim_get_current_buf()
-  self.editor_bufnr = editor_bufnr
   local visual_lines = {}
   -- if in visual, visual line, visual block modes
   if vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == "\22" then

--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -30,6 +30,8 @@ function Chat:init()
   -- quit indicator
   self.active = true
 
+  self.editor_bufnr = nil
+
   -- UI ELEMENTS
   self.layout = nil
   self.chat_panel = nil
@@ -736,6 +738,13 @@ function Chat:get_layout_params()
 end
 
 function Chat:open()
+  local editor_bufnr = vim.api.nvim_get_current_buf()
+  self.editor_bufnr = editor_bufnr
+  local visual_lines = {}
+  -- if in visual, visual line, visual block modes
+  if vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == "\22" then
+    visual_lines, _, _, _, _ = Utils.get_visual_lines(editor_bufnr)
+  end
   self.settings_panel = Settings.get_settings_panel("chat_completions", self.params)
   self.help_panel = Help.get_help_panel("chat")
   self.sessions_panel = Sessions.get_panel(function(session)
@@ -1017,6 +1026,8 @@ function Chat:open()
   self.chat_input:on(event.QuitPre, function()
     self.active = false
   end)
+
+  vim.api.nvim_buf_set_lines(self.chat_input.bufnr, -1, -1, false, visual_lines)
 end
 
 function Chat:open_system_panel()
@@ -1038,6 +1049,15 @@ function Chat:hide()
 end
 
 function Chat:show()
+  local editor_bufnr = vim.api.nvim_get_current_buf()
+  self.editor_bufnr = editor_bufnr
+  local visual_lines = {}
+  -- if in visual, visual line, visual block modes
+  if vim.fn.mode() == "v" or vim.fn.mode() == "V" or vim.fn.mode() == "\22" then
+    visual_lines, _, _, _, _ = Utils.get_visual_lines(editor_bufnr)
+  end
+  vim.api.nvim_buf_set_lines(self.chat_input.bufnr, -1, -1, false, visual_lines)
+
   self:redraw(true)
   self.layout:show()
 end


### PR DESCRIPTION
This pull request makes visual selection appended to default chat (`:ChatGPT`) to save time on keystrokes and because other commands (such as ChatGPTEditWithInstructions) do not store sessions. You can append multiple times without having your text in chat input window deleted.

Usage: 
1. go in any of the visual modes and select the text you want inserted. 
2. Run ChatGPT from a keybind mapped to `<cmd>ChatGPT<cr>` (else this won't work properly because of how visual selection works).