### PR TITLE
feat: trigger TextChanged event after updating buffer

### DIFF
--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -580,6 +580,7 @@ function Chat:set_lines(start_idx, end_idx, strict_indexing, lines)
   if not self.is_streaming_response_lock then
     Utils.modify_buf(self.chat_window.bufnr, function(bufnr)
       vim.api.nvim_buf_set_lines(bufnr, start_idx, end_idx, strict_indexing, lines)
+      vim.api.nvim_exec_autocmds("TextChanged", { buffer = bufnr })
     end)
   end
 end


### PR DESCRIPTION
## Details

Some users (or at least 1) use a plugin I own [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) to view ChatGPT sessions. My plugin adds some highlights and icons to improve viewing markdown in neovim.

When a session is changed from the sessions panel the `nvim_buf_set_lines` API is called which updates the contents of the buffer. However on my plugin's side I am unable to "see" that anything changed so do not update the rendering leading to this issue: https://github.com/MeanderingProgrammer/render-markdown.nvim/issues/210.

To bridge this gap I added a manual trigger of the `TextChanged` event after the API call which lets my plugin re-render the buffer.

LMK if there are any concerns with the change or if there is another approach I can take, thank you!