### PR TITLE
fix: max_tokens issue with o1 model (#473)

### DIFF
--- a/lua/chatgpt/api.lua
+++ b/lua/chatgpt/api.lua
@@ -19,6 +19,11 @@ function Api.chat_completions(custom_params, cb, should_stop)
   if params.model == "<dynamic>" then
     params.model = openai_params.model
   end
+  -- max_tokens is unsupported for o1 OpenAI models; older models are backward-compatible with max_tokens,
+  -- but max_completion_tokens works with all models.
+  params.max_completion_tokens = params.max_tokens
+  params.max_tokens = nil
+
   local stream = params.stream or false
   if stream then
     local raw_chunks = ""


### PR DESCRIPTION
This pull requests fixes the max_tokens error that users get when they try to use the newer o1 models. 

`Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`

The new o1 series of models deprecate the `max_tokens` parameter in favor of a new `max_completion_tokens` parameter and added support for `max_completion_tokens` on older models as well.

What this PR does is:
1. defaults 'max_tokens' to 'max_completion_tokens' 
2. removes 'max_tokens' 