### PR TITLE
Fix: q insert mode bug. restricts closing keymapping to normal mode only

### DIFF
--- a/lua/chatgpt/flows/chat/base.lua
+++ b/lua/chatgpt/flows/chat/base.lua
@@ -1547,7 +1547,7 @@ function Chat:open()
     if vim.fn.mode() == "i" then
       vim.api.nvim_command("stopinsert")
     end
-  end)
+  end, nil, { "n" })
 
   -- close_n
   if Config.options.chat.keymaps.close_n then


### PR DESCRIPTION
Fixes issue where typing 'q' in insert mode in the input window would trigger the quit action.                                                                                                                    
                                                                                                                                                                                                                    
The close keymapping was being applied to both normal and insert modes. This restricts it to normal mode only in the input window.         
